### PR TITLE
Make package-private properties of substitutionmodels protected instead

### DIFF
--- a/src/beast/evolution/substitutionmodel/GeneralSubstitutionModel.java
+++ b/src/beast/evolution/substitutionmodel/GeneralSubstitutionModel.java
@@ -52,7 +52,7 @@ public class GeneralSubstitutionModel extends SubstitutionModel.Base {
     /**
      * a square m_nStates x m_nStates matrix containing current rates  *
      */
-    double[][] rateMatrix;
+    protected double[][] rateMatrix;
 
 
     @Override

--- a/src/beast/evolution/substitutionmodel/SubstitutionModel.java
+++ b/src/beast/evolution/substitutionmodel/SubstitutionModel.java
@@ -101,12 +101,12 @@ public interface SubstitutionModel {
         /**
          * shadows frequencies, or can be set by subst model *
          */
-        Frequencies frequencies;
+        protected Frequencies frequencies;
 
         /**
          * number of states *
          */
-        int nrOfStates;
+        protected int nrOfStates;
 
         @Override
         public void initAndValidate() throws Exception {


### PR DESCRIPTION
As per issue #327  in order to write subclasses of SubstitutionModel and GeneralSubstitutionModel in external packages.