### PR TITLE
Remove leftover debugging code, which causes beast2 run failures 

### DIFF
--- a/src/beast/app/beastapp/BeastLauncher.java
+++ b/src/beast/app/beastapp/BeastLauncher.java
@@ -39,16 +39,6 @@ public class BeastLauncher {
 		String launcherJar = clu.getClass().getProtectionDomain().getCodeSource().getLocation().getPath();
 		// deal with special characters and spaces in path
 		launcherJar = URLDecoder.decode(launcherJar, "UTF-8");
-
-		// TODO remove following debugging code
-		try {
-			FileWriter outfile = new FileWriter("/tmp/beast.log");
-			outfile.write("jardir = " + launcherJar);
-			outfile.close();
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-
 		Log.warning.println("jardir = " + launcherJar);
 		File jarDir0 = new File(launcherJar).getParentFile();
 		boolean foundOne = false;


### PR DESCRIPTION
In multi-user environments beast can't be writing to a hardcoded /tmp/beast.log path. This pull request removes the code already tagged for removal, but apparently forgotten and left in the released package for 2.3.2.