### PR TITLE
Make DeltaExchangeOperator deal with changing weight vectors

### DIFF
--- a/src/beast/app/beauti/BeautiAlignmentProvider.java
+++ b/src/beast/app/beauti/BeautiAlignmentProvider.java
@@ -58,7 +58,7 @@ public class BeautiAlignmentProvider extends BEASTObject {
 	/** 
 	 * return new alignment, return null if not successful 
 	 * **/
-	List<BEASTInterface> getAlignments(BeautiDoc doc) {
+	protected List<BEASTInterface> getAlignments(BeautiDoc doc) {
         File [] files = beast.app.util.Utils.getLoadFiles("Load Alignment File",
                 new File(Beauti.g_sDir), "Alignment files", "xml", 
                 "fa","fas","fst","fasta","fna","ffn","faa","frn",

--- a/src/beast/evolution/likelihood/TreeLikelihood.java
+++ b/src/beast/evolution/likelihood/TreeLikelihood.java
@@ -349,9 +349,13 @@ public class TreeLikelihood extends GenericTreeLikelihood {
         }
         final TreeInterface tree = treeInput.get();
 
-        if (traverse(tree.getRoot()) != Tree.IS_CLEAN)
-            calcLogP();
-
+        try {
+        	if (traverse(tree.getRoot()) != Tree.IS_CLEAN)
+        		calcLogP();
+        }
+        catch (ArithmeticException e) {
+        	return Double.NEGATIVE_INFINITY;
+        }
         m_nScale++;
         if (logP > 0 || (likelihoodCore.getUseScaling() && m_nScale > X)) {
 //            System.err.println("Switch off scaling");

--- a/src/beast/evolution/operators/DeltaExchangeOperator.java
+++ b/src/beast/evolution/operators/DeltaExchangeOperator.java
@@ -4,6 +4,7 @@ package beast.evolution.operators;
 
 import java.text.DecimalFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import beast.core.Description;
@@ -41,13 +42,49 @@ public class DeltaExchangeOperator extends Operator {
     private boolean autoOptimize;
     private double delta;
     private boolean isIntegerOperator;
-    private int[] parameterWeights;
     private CompoundParameterHelper compoundParameter = null;
     // because CompoundParameter cannot derive from parameter due to framework, the code complexity is doubled
 
-    @Override
-	public void initAndValidate() {
+	private int[] weights() {
+		int[] weights;
+		if (compoundParameter == null) { // one parameter case
+			if (parameterInput.get().isEmpty()) {
+				if (intparameterInput.get().size() > 0) {
+					weights = new int[intparameterInput.get().get(0)
+							.getDimension()];
+				} else {
+					// happens when BEAUti is setting things up
+					weights = new int[0];
+				}
+			} else {
+				weights = new int[parameterInput.get().get(0).getDimension()];
+			}
+		} else {
+			if (compoundParameter.getDimension() < 1)
+				throw new IllegalArgumentException(
+						"Compound parameter is not created properly, dimension = "
+								+ compoundParameter.getDimension());
 
+			weights = new int[compoundParameter.getDimension()];
+		}
+
+		if (parameterWeightsInput.get() != null) {
+			if (weights.length != parameterWeightsInput.get().getDimension())
+				throw new IllegalArgumentException(
+						"Weights vector should have the same length as parameter dimension");
+
+			for (int i = 0; i < weights.length; i++) {
+				weights[i] = parameterWeightsInput.get().getValue(i);
+			}
+		} else {
+			for (int i = 0; i < weights.length; i++) {
+				weights[i] = 1;
+			}
+		}
+		return weights;
+	}
+
+    public void initAndValidate() {
         autoOptimize = autoOptimizeiInput.get();
         delta = deltaInput.get();
         isIntegerOperator = integerOperatorInput.get();
@@ -80,37 +117,6 @@ public class DeltaExchangeOperator extends Operator {
             }
         }
 
-        if (compoundParameter == null) { // one parameter case
-            if (parameterInput.get().isEmpty()) {
-            	if (intparameterInput.get().size() > 0) {
-            		parameterWeights = new int[intparameterInput.get().get(0).getDimension()];
-            	} else {
-            		// happens when BEAUti is setting things up
-            		parameterWeights = new int[0];
-            	}
-            } else {
-                parameterWeights = new int[parameterInput.get().get(0).getDimension()];
-            }
-        } else {
-            if (compoundParameter.getDimension() < 1)
-                throw new IllegalArgumentException("Compound parameter is not created properly, dimension = " + compoundParameter.getDimension());
-
-            parameterWeights = new int[compoundParameter.getDimension()];
-        }
-
-        if (parameterWeightsInput.get() != null) {
-            if (parameterWeights.length != parameterWeightsInput.get().getDimension())
-                throw new IllegalArgumentException("Weights vector should have the same length as parameter dimension");
-
-            for (int i = 0; i < parameterWeights.length; i++) {
-                parameterWeights[i] = parameterWeightsInput.get().getValue(i);
-            }
-        } else {
-            for (int i = 0; i < parameterWeights.length; i++) {
-                parameterWeights[i] = 1;
-            }
-        }
-
         if (isIntegerOperator && delta != Math.round(delta)) {
             throw new IllegalArgumentException("Can't be an integer operator if delta is not integer");
         }
@@ -131,6 +137,7 @@ public class DeltaExchangeOperator extends Operator {
 
     @Override
     public final double proposal() {
+    	int[] parameterWeights = weights();
         double logq = 0.0;
 
         if (compoundParameter == null) { // one parameter case


### PR DESCRIPTION
DeltaExchangeOperators are nice for constant-sum items, as appear in reversible-jump methods for estimating the number of different rates. In that case, the weight vector can change over time.

This commit allows beast2's DeltaExchangeOperator to deal with changing weight vectors.