### PR TITLE
Changes without much effect, simplifying package writing.

### DIFF
--- a/src/beast/app/beauti/BeautiAlignmentProvider.java
+++ b/src/beast/app/beauti/BeautiAlignmentProvider.java
@@ -161,6 +161,11 @@ public class BeautiAlignmentProvider extends BEASTObject {
                     break;
 			}
         }
+        addAlignments(doc, selectedBEASTObjects);
+        return selectedBEASTObjects;
+    }
+    
+    protected void addAlignments(BeautiDoc doc, List<BEASTInterface> selectedBEASTObjects) {
         for (BEASTInterface beastObject : selectedBEASTObjects) {
         	// ensure ID of alignment is unique
         	int k = 0;
@@ -173,7 +178,6 @@ public class BeautiAlignmentProvider extends BEASTObject {
         	sortByTaxonName(((Alignment) beastObject).sequenceInput.get());
             doc.addAlignmentWithSubnet((Alignment) beastObject, getStartTemplate());
         }
-        return selectedBEASTObjects;
     }
 
 	/** provide GUI for manipulating the alignment **/
@@ -196,11 +200,11 @@ public class BeautiAlignmentProvider extends BEASTObject {
 	
 	/** return template to apply to this new alignment.
 	 * By default, the partition template of the current beauti template is returned **/
-	BeautiSubTemplate getStartTemplate() {
+	protected BeautiSubTemplate getStartTemplate() {
 		return template.get();
 	}
 
-    private void sortByTaxonName(List<Sequence> seqs) {
+    protected void sortByTaxonName(List<Sequence> seqs) {
         Collections.sort(seqs, (Sequence o1, Sequence o2) -> {
                 return o1.taxonInput.get().compareTo(o2.taxonInput.get());
             }

--- a/src/beast/app/beauti/BeautiAlignmentProvider.java
+++ b/src/beast/app/beauti/BeautiAlignmentProvider.java
@@ -54,7 +54,7 @@ public class BeautiAlignmentProvider extends BEASTObject {
 	 * return amount to which the provided matches an alignment 
 	 * The provider with the highest match will be used to edit the alignment 
 	 * */
-	int matches(Alignment alignment) {
+	protected int matches(Alignment alignment) {
 		return 1;
 	}
 	

--- a/src/beast/core/Input.java
+++ b/src/beast/core/Input.java
@@ -748,5 +748,9 @@ public class Input<T> {
                 break;
         }
     } // validate
+    
+    public String toString() {
+    	return String.format("Input(\"%s\")", name);
+    }
 
 } // class Input

--- a/src/beast/evolution/likelihood/BeagleTreeLikelihood.java
+++ b/src/beast/evolution/likelihood/BeagleTreeLikelihood.java
@@ -34,6 +34,7 @@ import beagle.BeagleFlag;
 import beagle.BeagleInfo;
 import beagle.InstanceDetails;
 import beagle.ResourceDetails;
+import beast.core.CalculationNode;
 import beast.core.Description;
 import beast.core.util.Log;
 import beast.evolution.alignment.Alignment;
@@ -501,8 +502,10 @@ public class BeagleTreeLikelihood extends TreeLikelihood {
         hasDirt = Tree.IS_CLEAN;
 
         updateSiteModel |= m_siteModel.isDirtyCalculation();
-        updateSubstitutionModel |= substitutionModel.isDirtyCalculation();
-
+        if (substitutionModel instanceof CalculationNode) {
+        	updateSubstitutionModel |= ((CalculationNode) substitutionModel).isDirtyCalculation();
+        }
+        
         if (dataInput.get().isDirtyCalculation()) {
             hasDirt = Tree.IS_FILTHY;
             return true;

--- a/src/beast/evolution/likelihood/TreeLikelihood.java
+++ b/src/beast/evolution/likelihood/TreeLikelihood.java
@@ -68,7 +68,7 @@ public class TreeLikelihood extends GenericTreeLikelihood {
      * BEASTObject associated with inputs. Since none of the inputs are StateNodes, it
      * is safe to link to them only once, during initAndValidate.
      */
-    SubstitutionModel.Base substitutionModel;
+    SubstitutionModel substitutionModel;
     protected SiteModel.Base m_siteModel;
     protected BranchRateModel.Base branchRateModel;
 

--- a/src/beast/evolution/sitemodel/SiteModelInterface.java
+++ b/src/beast/evolution/sitemodel/SiteModelInterface.java
@@ -35,7 +35,7 @@ public interface SiteModelInterface {
 
     @Description(value = "Base implementation of a site model with substitution model and rate categories.", isInheritable = false)
     public abstract class Base extends CalculationNode implements SiteModelInterface {
-    	final public Input<SubstitutionModel.Base> substModelInput =
+    	final public Input<SubstitutionModel> substModelInput =
                 new Input<>("substModel", "substitution model along branches in the beast.tree", null, Validate.REQUIRED);
 
     	/**


### PR DESCRIPTION
This pull request contains three minor changes to make package authors' lives easier.

It fixes #510, which does hardly affect the Beast core because all `SubstitutionModel`s in there are already `SubstitutionModel.Base`s, but the one I'm working on is not. **Note: A trivial approach breaks with BeagleTreeLikelihood. This is fixed as well.**

It gives input objects a more helpful `toString()`, at least showing their name.

Splitting a `BeautiAlignmentProvider` method into two allows a subclass to override only one of file parsing and alignment processing, and also some of its methods were not accessible from possible sub-classes.