### PR TITLE
Make TraitSet work with unspecified dates.

### DIFF
--- a/src/beast/evolution/tree/TraitSet.java
+++ b/src/beast/evolution/tree/TraitSet.java
@@ -98,7 +98,8 @@ public class TraitSet extends BEASTObject {
         // sanity check: did we cover all taxa?
         for (int i = 0; i < labels.size(); i++) {
             if (taxonValues[i] == null) {
-                Log.warning.println("WARNING: no trait specified for " + labels.get(i));
+                Log.warning.println("WARNING: no trait specified for " + labels.get(i) +": Assumed to be 0");
+                map.put(labels.get(i), i);
             }
         }
 

--- a/src/test/beast/evolution/tree/TraitSetTest.java
+++ b/src/test/beast/evolution/tree/TraitSetTest.java
@@ -1,0 +1,78 @@
+/**
+ * 
+ */
+package test.beast.evolution.tree;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import beast.evolution.alignment.Alignment;
+import beast.evolution.alignment.Sequence;
+import beast.evolution.alignment.TaxonSet;
+import beast.evolution.tree.TraitSet;
+
+/**
+ * @author Gereon Kaiping <g.a.kaiping@hum.leidenuniv.nl>
+ *
+ */
+public class TraitSetTest {
+	
+	public TaxonSet taxonSet(int Nleaves) {
+    List<Sequence> seqList = new ArrayList<Sequence>();
+
+    for (int i=0; i<Nleaves; i++) {
+        String taxonID = "t" + i;
+        seqList.add(new Sequence(taxonID, "?"));
+    }
+
+    Alignment alignment = new Alignment(seqList, "nucleotide");
+    TaxonSet taxonSet = new TaxonSet(alignment);
+    return taxonSet;}
+	
+
+	@Test
+	public void testDateBackward() {
+		int Nleaves = 2; 
+	    TraitSet timeTrait = new TraitSet();
+
+	    timeTrait.initByName(
+	            "traitname", "date-backward",
+	            "taxa", taxonSet(Nleaves),
+	            "value", "t0=0, t1=10");
+	    // The trait actually represents the age of the taxa relative to
+	    // each other with arbitrary zero, so we test it like this.
+	    assertEquals(-10.0, timeTrait.getValue("t0")-timeTrait.getValue("t1"), 1e-7);
+	}
+
+	@Test
+	public void testDateForward() {
+		int Nleaves = 2; 
+	    TraitSet timeTrait = new TraitSet();
+
+	    timeTrait.initByName(
+	            "traitname", "date-forward",
+	            "taxa", taxonSet(Nleaves),
+	            "value", "t0=0, t1=10");
+	    // The trait actually represents the age of the taxa relative to
+	    // each other with arbitrary zero, so we test it like this.
+	    assertEquals(10.0, timeTrait.getValue("t0")-timeTrait.getValue("t1"), 1e-7);
+	}
+
+	@Test
+	public void testDateForwardUnspecified() {
+		int Nleaves = 2; 
+	    TraitSet timeTrait = new TraitSet();
+
+	    timeTrait.initByName(
+	            "traitname", "date-forward",
+	            "taxa", taxonSet(Nleaves),
+	            "value", "t1=10");
+	    // The trait actually represents the age of the taxa relative to
+	    // each other with arbitrary zero, so we test it like this.
+	    assertEquals(10.0, timeTrait.getValue("t0")-timeTrait.getValue("t1"), 1e-7);
+	}
+}


### PR DESCRIPTION
Make TraitSet fill unspecified trait values with 0, as its
log messages suggest, and write some very basic tests for
this and TraitSet's basic functionality.
Fixes #593.