### PR TITLE
Normalise statenode strings

### DIFF
--- a/src/beast/core/StateNode.java
+++ b/src/beast/core/StateNode.java
@@ -110,7 +110,7 @@ public abstract class StateNode extends CalculationNode implements Loggable, Clo
      */
     final public void toXML(PrintStream out) {
         out.print("<statenode id='" + normalise(getID()) + "'>");
-        out.print(toString());
+        out.print(normalise(toString()));
         out.print("</statenode>\n");
     }
 
@@ -119,7 +119,7 @@ public abstract class StateNode extends CalculationNode implements Loggable, Clo
      */
     final public String toXML() {
         return "<statenode id='" + normalise(getID()) + "'>" +
-                toString() +
+                normalise(toString()) +
                 "</statenode>\n";
     }
 


### PR DESCRIPTION
This is needed to store extended newick information in .state files for resuming. An alternative would be to remove the final modifier for the toXML methods, and override them in relevant statenodes.