### PR TITLE
BEAUti tests now run in docker container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,31 @@
-# Dockerfile to build container for unit testing
+# Dockerfile to build container for unit testing.
+#
+# To build the image, run the following from this directory:
+#   docker build -t beast_testing .
+#
+# To run the tests, use
+#   docker run beast_testing
+#
+# To run the tests interactively, use
+#   docker run -it -p 5900:5900 beast_testing /bin/bash
+# This will give you a shell in the container. From this
+# shell, run
+#   vncserver $DISPLAY -geometry 1920x1080; ant travis
+#
+# The previous command exposes the VNC session, so while the
+# BEAUti test suite is running you can run a VNC viewer and
+# connect it to localhost (password: password) to observe
+# the graphical output of these tests.
 
 FROM openjdk:8
 
-RUN apt-get update && apt-get install -y git ant
+RUN apt-get update && apt-get install -y ant tightvncserver twm
+
+ENV DISPLAY :0
+ENV USER root
+RUN mkdir /root/.vnc
+RUN echo password | vncpasswd -f > /root/.vnc/passwd
+RUN chmod 600 /root/.vnc/passwd
 
 # Ant build fails if the repo dir isn't named beast2
 RUN mkdir /root/beast2
@@ -10,4 +33,4 @@ WORKDIR /root/beast2
 
 ADD . ./
 
-CMD ant travis
+CMD vncserver $DISPLAY -geometry 1920x1080; ant travis

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 BEAST 2
 =======
-[![Build & test (exclude BEAUti)](https://travis-ci.org/CompEvol/beast2.svg?branch=master)](https://travis-ci.org/CompEvol/beast2)
 
 BEAST is a cross-platform program for Bayesian inference using MCMC of
 molecular sequences. It is entirely orientated towards rooted,

--- a/build.xml
+++ b/build.xml
@@ -215,14 +215,14 @@
     </target>
 
     <!-- Target for Travis-CI with non-zero exit status on test failure. -->
-    <target name="travis" depends="clean, compile-all, junit">
+    <target name="travis" depends="clean, compile-all, junit, junitb">
         <fail if="junitfailed" message="One or more unit tests failed."/>
     </target>
 
     <!-- testing beauti gui-->
     <target name="junitb">
         <mkdir dir="${report}" />
-        <junit printsummary="yes">
+        <junit printsummary="yes" failureproperty="junitfailed">
             <!--showoutput='yes'-->
             <classpath>
                 <path refid="classpath" />


### PR DESCRIPTION
I've managed to get the BEAUti fest tests running in a Docker container.  They don't all pass (see the tail of [this travis build log](https://travis-ci.org/tgvaughan/beast2/builds/237462986)) but that isn't the point.  In this form, the tests can be run locally in _exactly_ the same environment, either interactively or not, which should make responding to test failures much easier.  It also democratizes the testing a bit, as it allows anybody at all to access the test environment.

What do you guys think?

Brief details on how to build and run the tests, as well as how to observe them using a VNC viewer, are currently in the comments at the head of Dockerfile.  (This should be extended and incorporated into the README, along with general build instructions.)