### PR TITLE
User-specified tip date format in BEAUti. Issue #729.

### DIFF
--- a/src/beast/app/beauti/TipDatesInputEditor.java
+++ b/src/beast/app/beauti/TipDatesInputEditor.java
@@ -1,19 +1,5 @@
 package beast.app.beauti;
 
-import java.awt.*;
-import java.text.DateFormat;
-import java.time.format.DateTimeParseException;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.EventObject;
-import java.util.GregorianCalendar;
-import java.util.List;
-
-import javax.swing.*;
-import javax.swing.event.CellEditorListener;
-import javax.swing.table.TableCellEditor;
-import javax.swing.table.TableCellRenderer;
-
 import beast.app.draw.BEASTObjectInputEditor;
 import beast.core.BEASTInterface;
 import beast.core.Input;
@@ -21,6 +7,16 @@ import beast.core.util.Log;
 import beast.evolution.alignment.Taxon;
 import beast.evolution.tree.TraitSet;
 import beast.evolution.tree.Tree;
+
+import javax.swing.*;
+import javax.swing.event.CellEditorListener;
+import javax.swing.table.TableCellEditor;
+import javax.swing.table.TableCellRenderer;
+import java.awt.*;
+import java.text.DateFormat;
+import java.time.format.DateTimeParseException;
+import java.util.EventObject;
+import java.util.List;
 
 public class TipDatesInputEditor extends BEASTObjectInputEditor {
 
@@ -145,15 +141,7 @@ public class TipDatesInputEditor extends BEASTObjectInputEditor {
             public boolean stopCellEditing() {
                 table.removeEditor();
                 String text = m_textField.getText();
-//                try {
-//                    Double.parseDouble(text);
-//                } catch (Exception e) {
-//                	try {
-//                		Date.parse(text);
-//                	} catch (Exception e2) {
-//                        return false;
-//					}
-//                }
+
                 tableData[m_iRow][m_iCol] = text;
                 convertTableDataToTrait();
                 convertTraitToTableData();
@@ -202,37 +190,6 @@ public class TipDatesInputEditor extends BEASTObjectInputEditor {
         table.setRowHeight(24 * fontsize / 13);
         scrollPane = new JScrollPane(table);
 
-// AJD: This ComponentListener breaks the resizing of the tip dates table, so I have removed it.
-//        scrollPane.addComponentListener(new ComponentListener() {
-//            @Override
-//            public void componentShown(ComponentEvent e) {}
-//
-//            @Override
-//            public void componentResized(ComponentEvent e) {
-//                Component c = (Component) e.getSource();
-//                while (c.getParent() != null && !(c.getParent() instanceof JSplitPane)) {
-//                    c = c.getParent();
-//                }
-//                if (c.getParent() != null) {
-//                    Dimension preferredSize = c.getSize();
-//                    preferredSize.height = Math.max(preferredSize.height - 170, 0);
-//                    preferredSize.width = Math.max(preferredSize.width - 25, 0);
-//                    scrollPane.setPreferredSize(preferredSize);
-//                } else if (doc.getFrame() != null) {
-//                    Dimension preferredSize = doc.getFrame().getSize();
-//                    preferredSize.height = Math.max(preferredSize.height - 170, 0);
-//                    preferredSize.width = Math.max(preferredSize.width - 25, 0);
-//                    scrollPane.setPreferredSize(preferredSize);
-//                }
-//            }
-//
-//            @Override
-//            public void componentMoved(ComponentEvent e) {}
-//
-//            @Override
-//            public void componentHidden(ComponentEvent e) {}
-//        });
-
         return scrollPane;
     } // createListBox
 
@@ -255,13 +212,11 @@ public class TipDatesInputEditor extends BEASTObjectInputEditor {
             String[] strs = trait.split("=");
             if (strs.length != 2) {
                 break;
-                //throw new Exception("could not parse trait: " + trait);
             }
+
             String taxonID = normalize(strs[0]);
             int taxonIndex = taxa.indexOf(taxonID);
-//            if (taxonIndex < 0) {
-//                throw new Exception("Trait (" + taxonID + ") is not a known taxon. Spelling error perhaps?");
-//            }
+
             if (taxonIndex >= 0) {
                 tableData[taxonIndex][1] = normalize(strs[1]);
                 tableData[taxonIndex][0] = taxonID;
@@ -345,8 +300,13 @@ public class TipDatesInputEditor extends BEASTObjectInputEditor {
         Box buttonBox = Box.createHorizontalBox();
 
         JLabel label = new JLabel("Dates specified: ");
+        label.setAlignmentY(Component.TOP_ALIGNMENT);
         label.setMaximumSize(label.getPreferredSize());
         buttonBox.add(label);
+
+        Box formatBox = Box.createVerticalBox();
+        Box formatBoxFirstLine = Box.createHorizontalBox();
+        Box formatBoxSecondLine = Box.createHorizontalBox();
 
         radioButtonGroup = new ButtonGroup();
         numericRadioButton = new JRadioButton("numerically as");
@@ -361,7 +321,7 @@ public class TipDatesInputEditor extends BEASTObjectInputEditor {
         });
 
         radioButtonGroup.add(numericRadioButton);
-        buttonBox.add(numericRadioButton);
+        formatBoxFirstLine.add(numericRadioButton);
 
         unitsComboBox = new JComboBox<>(TraitSet.Units.values());
         unitsComboBox.setSelectedItem(traitSet.unitsInput.get());
@@ -375,10 +335,10 @@ public class TipDatesInputEditor extends BEASTObjectInputEditor {
                 }
             });
         Dimension d = unitsComboBox.getPreferredSize();
-        unitsComboBox.setMaximumSize(new Dimension(Integer.MAX_VALUE, unitsComboBox.getPreferredSize().height));
+        unitsComboBox.setMaximumSize(unitsComboBox.getPreferredSize());
         unitsComboBox.setSize(d);
         unitsComboBox.setEnabled(numericRadioButton.isSelected());
-        buttonBox.add(unitsComboBox);
+        formatBoxFirstLine.add(unitsComboBox);
 
         relativeToComboBox = new JComboBox<>(new String[]{"Since some time in the past", "Before the present"});
         relativeToComboBox.setToolTipText("Whether dates go forward or backward");
@@ -400,9 +360,11 @@ public class TipDatesInputEditor extends BEASTObjectInputEditor {
                 }
                 convertTraitToTableData();
             });
-        relativeToComboBox.setMaximumSize(new Dimension(Integer.MAX_VALUE, relativeToComboBox.getPreferredSize().height));
+        relativeToComboBox.setMaximumSize(relativeToComboBox.getPreferredSize());
         relativeToComboBox.setEnabled(numericRadioButton.isSelected());
-        buttonBox.add(relativeToComboBox);
+        formatBoxFirstLine.add(relativeToComboBox);
+        formatBoxFirstLine.add(Box.createHorizontalGlue());
+        formatBox.add(formatBoxFirstLine);
 
         formattedDateRadioButton = new JRadioButton("as dates with format");
         formattedDateRadioButton.setToolTipText("Interpret values as dates with the given format.");
@@ -415,7 +377,7 @@ public class TipDatesInputEditor extends BEASTObjectInputEditor {
             refreshPanel();
         });
         radioButtonGroup.add(formattedDateRadioButton);
-        buttonBox.add(formattedDateRadioButton);
+        formatBoxSecondLine.add(formattedDateRadioButton);
 
         String[] dateFormatExamples = {
                 "dd/M/yyyy",
@@ -432,17 +394,23 @@ public class TipDatesInputEditor extends BEASTObjectInputEditor {
             dateFormatComboBox.setSelectedItem(traitSet.dateTimeFormatInput.get());
         else
             dateFormatComboBox.setSelectedItem(dateFormatExamples[0]);
-        dateFormatComboBox.setMaximumSize((new Dimension(Integer.MAX_VALUE, dateFormatComboBox.getPreferredSize().height)));
+        dateFormatComboBox.setMaximumSize(dateFormatComboBox.getPreferredSize());
         dateFormatComboBox.setEnabled(formattedDateRadioButton.isSelected());
         dateFormatComboBox.addActionListener(e -> {
             traitSet.dateTimeFormatInput.setValue(dateFormatComboBox.getSelectedItem(), traitSet);
             refreshPanel();
         });
-        buttonBox.add(dateFormatComboBox);
+
+        formatBoxSecondLine.add(dateFormatComboBox);
+        formatBoxSecondLine.add(Box.createHorizontalGlue());
+        formatBox.add(formatBoxSecondLine);
+        formatBox.setAlignmentY(TOP_ALIGNMENT);
+        buttonBox.add(formatBox);
 
         buttonBox.add(Box.createHorizontalGlue());
 
         JButton guessButton = new JButton("Auto-configure");
+        guessButton.setAlignmentY(TOP_ALIGNMENT);
         guessButton.setToolTipText("Automatically configure dates based on taxon names");
         guessButton.setName("Guess");
         guessButton.addActionListener(e -> {
@@ -470,8 +438,6 @@ public class TipDatesInputEditor extends BEASTObjectInputEditor {
                 }
                 try {
                     traitSet.traitsInput.setValue(trait, traitSet);
-//                    convertTraitToTableData();
-//                    convertTableDataToTrait();
                 } catch (Exception ex) {
                     // TODO: handle exception
                 }
@@ -481,6 +447,7 @@ public class TipDatesInputEditor extends BEASTObjectInputEditor {
 
 
         JButton clearButton = new JButton("Clear");
+        clearButton.setAlignmentY(TOP_ALIGNMENT);
         clearButton.setToolTipText("Set all dates to zero");
         clearButton.addActionListener(e -> {
                 try {

--- a/src/beast/evolution/tree/TraitSet.java
+++ b/src/beast/evolution/tree/TraitSet.java
@@ -88,7 +88,16 @@ public class TraitSet extends BEASTObject {
                 throw new IllegalArgumentException("Trait (" + taxonID + ") is not a known taxon. Spelling error perhaps?");
             }
             taxonValues[taxonNr] = normalize(strs[1]);
-            values[taxonNr] = parseDouble(taxonValues[taxonNr]);
+            try {
+                values[taxonNr] = convertValueToDouble(taxonValues[taxonNr]);
+            } catch (DateTimeParseException ex) {
+                Log.err.println("Failed to parse date '" + taxonValues[taxonNr] + "' using format '" + dateTimeFormatInput.get() + "'.");
+                System.exit(1);
+            } catch (IllegalArgumentException ex) {
+                Log.err.println("Failed to parse date '" + taxonValues[taxonNr] + "'.");
+                System.exit(1);
+            }
+
             map.put(taxonID, taxonNr);
             
             if (Double.isNaN(values[taxonNr]))
@@ -172,54 +181,49 @@ public class TraitSet extends BEASTObject {
     /**
      * see if we can convert the string to a double value *
      */
-    private double parseDouble(String str) {
+    public double convertValueToDouble(String str) {
         // default, try to interpret the string as a number
         try {
             return Double.parseDouble(str);
         } catch (NumberFormatException e) {
             // does not look like a number
-                if (traitNameInput.get().equals(DATE_TRAIT) ||
-                        traitNameInput.get().equals(DATE_FORWARD_TRAIT) ||
-                        traitNameInput.get().equals(DATE_BACKWARD_TRAIT)) {
+            if (traitNameInput.get().equals(DATE_TRAIT) ||
+                    traitNameInput.get().equals(DATE_FORWARD_TRAIT) ||
+                    traitNameInput.get().equals(DATE_BACKWARD_TRAIT)) {
 
-                        try {
-                            double year;
-                            if (dateTimeFormatInput.get() == null) {
-                                if (str.matches(".*[a-zA-Z].*")) {
-                                        str = str.replace('/', '-');
-                                }
-                                // following is deprecated, but the best thing around at the moment
-                                // see also comments in TipDatesInputEditor
-                                long date = Date.parse(str);
-                                year = 1970.0 + date / (60.0 * 60 * 24 * 365 * 1000);
-                                Log.warning.println("No date/time format provided, using default parsing: '" + str + "' parsed as '" + year + "'");
-                            } else {
-                                DateTimeFormatter formatter = DateTimeFormatter.ofPattern(dateTimeFormatInput.get());
-                                LocalDate date = LocalDate.parse(str, formatter);
-
-                                Log.warning.println("Using format '" + dateTimeFormatInput.get() + "' to parse '" + str +
-                                        "' as: " + (date.getYear() + (date.getDayOfYear()-1.0) / (date.isLeapYear() ? 366.0 : 365.0)));
-
-                                year = date.getYear() + (date.getDayOfYear()-1.0) / (date.isLeapYear() ? 366.0 : 365.0);
-                            }
-
-                            switch (unitsInput.get()) {
-                                case month:
-                                    return year * 12.0;
-                                case day:
-                                    return year * 365;
-                                default:
-                                    return year;
-                            }
-                        } catch (DateTimeParseException e2) {
-                            Log.err.println("Failed to parse date '" + str + "' using format '" + dateTimeFormatInput.get() + "'");
-                            System.exit(1);
-                        }
+                double year;
+                if (dateTimeFormatInput.get() == null) {
+                    if (str.matches(".*[a-zA-Z].*")) {
+                        str = str.replace('/', '-');
                     }
+                    // following is deprecated, but the best thing around at the moment
+                    // see also comments in TipDatesInputEditor
+                    long date = Date.parse(str);
+                    year = 1970.0 + date / (60.0 * 60 * 24 * 365 * 1000);
+                    Log.warning.println("No date/time format provided, using default parsing: '" + str + "' parsed as '" + year + "'");
+                } else {
+                    DateTimeFormatter formatter = DateTimeFormatter.ofPattern(dateTimeFormatInput.get());
+                    LocalDate date = LocalDate.parse(str, formatter);
+
+                    Log.warning.println("Using format '" + dateTimeFormatInput.get() + "' to parse '" + str +
+                            "' as: " + (date.getYear() + (date.getDayOfYear()-1.0) / (date.isLeapYear() ? 366.0 : 365.0)));
+
+                    year = date.getYear() + (date.getDayOfYear()-1.0) / (date.isLeapYear() ? 366.0 : 365.0);
                 }
-        //return 0;
+
+                switch (unitsInput.get()) {
+                    case month:
+                        return year * 12.0;
+                    case day:
+                        return year * 365;
+                    default:
+                        return year;
+                }
+            }
+        }
+
         return Double.NaN;
-    } // parseStrings
+    }
 
     /**
      * remove start and end spaces
@@ -234,6 +238,13 @@ public class TraitSet extends BEASTObject {
         return str;
     }
 
+    /**
+     * Retrieve absolute date from height above most recent sample.
+     *
+     * @param height age before most recent sample.
+     * @return date, which may be either backward-time or forward-time depending
+     * on the trait.  If trait type is not defined, the height itself is returned.
+     */
     public double getDate(double height) {
         if (traitNameInput.get().equals(DATE_TRAIT) || traitNameInput.get().equals(DATE_FORWARD_TRAIT)) {
             return maxValue - height;
@@ -244,7 +255,7 @@ public class TraitSet extends BEASTObject {
         }
         return height;
     }
-    
+
     /**
      * Determines whether trait is recognised as specifying taxa dates.
      * @return true if this is a date trait.


### PR DESCRIPTION
This commit does a few things:
1. Causes the "Date" column of the tip date input editor table to
contain the raw trait values.
2. Stores these raw values in the corresponding TraitSet. This means
that the XML file contains the original trait values (eg. dates like
2014-03-13).
3. Uses a previously private method in the TraitSet class to process
the dates (this is the same method that BEAST uses) and populate the
"Height" column of the input editor table.
4. Moves the error handling (previously a System.exit(1)) out of the
TraitSet trait value conversion method to an exception handler in the
calling code.
5. Provides a combo-box for specifying the date format that is recorded
in the dateFormat input to TraitSet.