### PR TITLE
Turn package-private fields into protected fields

### DIFF
--- a/src/beast/evolution/likelihood/TreeLikelihood.java
+++ b/src/beast/evolution/likelihood/TreeLikelihood.java
@@ -64,7 +64,7 @@ public class TreeLikelihood extends GenericTreeLikelihood {
      * calculation engine *
      */
     protected LikelihoodCore likelihoodCore;
-    BeagleTreeLikelihood beagle;
+    protected BeagleTreeLikelihood beagle;
 
     /**
      * BEASTObject associated with inputs. Since none of the inputs are StateNodes, it
@@ -105,14 +105,14 @@ public class TreeLikelihood extends GenericTreeLikelihood {
     /**
      * memory allocation for probability tables obtained from the SiteModel *
      */
-    double[] probabilities;
+    protected double[] probabilities;
 
-    int matrixSize;
+    protected int matrixSize;
 
     /**
      * flag to indicate ascertainment correction should be applied *
      */
-    boolean useAscertainedSitePatterns = false;
+    protected boolean useAscertainedSitePatterns = false;
 
     /**
      * dealing with proportion of site being invariant *


### PR DESCRIPTION
When writing a derivative class of TreeLikelihood in its own namespace, I noticed some more (I have made similar commits earlier, for other classes) fields that were package-private but should actually be `protected` to allow for clean inheritance.