### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/doc/tutorials/DivergenceDating/DivergenceDatingTutorial.bib
+++ b/doc/tutorials/DivergenceDating/DivergenceDatingTutorial.bib
@@ -108,4 +108,4 @@
 	Title = {Calibrated tree priors for relaxed phylogenetics and divergence time estimation},
 	Volume = {61},
 	Year = {2012},
-	Bdsk-Url-1 = {http://dx.doi.org/10.1093/sysbio/syr087}}
+	Bdsk-Url-1 = {https://doi.org/10.1093/sysbio/syr087}}

--- a/doc/tutorials/EBSP/ebsp2-tut.bib
+++ b/doc/tutorials/EBSP/ebsp2-tut.bib
@@ -23,7 +23,7 @@
   Pii                      = {PCOMPBIOL-D-13-02115},
   Pmid                     = {24722319},
   Timestamp                = {2015.05.07},
-  Url                      = {http://dx.doi.org/10.1371/journal.pcbi.1003537}
+  Url                      = {https://doi.org/10.1371/journal.pcbi.1003537}
 }
 
 @Article{Heled2008,
@@ -46,6 +46,6 @@
   Pii                      = {1471-2148-8-289},
   Pmid                     = {18947398},
   Timestamp                = {2016.01.11},
-  Url                      = {http://dx.doi.org/10.1186/1471-2148-8-289}
+  Url                      = {https://doi.org/10.1186/1471-2148-8-289}
 }
 

--- a/doc/tutorials/MEPs/MEPs.bib
+++ b/doc/tutorials/MEPs/MEPs.bib
@@ -34,5 +34,5 @@
 	Title = {Genetic variability and molecular evolution of the human respiratory syncytial virus subgroup B attachment G protein},
 	Volume = {79},
 	Year = {2005},
-	Bdsk-Url-1 = {http://dx.doi.org/10.1128/JVI.79.14.9157-9167.2005}}
+	Bdsk-Url-1 = {https://doi.org/10.1128/JVI.79.14.9157-9167.2005}}
 

--- a/doc/tutorials/STACEY/STACEY_tutorial.bib
+++ b/doc/tutorials/STACEY/STACEY_tutorial.bib
@@ -16,7 +16,7 @@
 	Title = {Bayesian inference of species trees from multilocus data},
 	Volume = {27},
 	Year = {2010},
-	Bdsk-Url-1 = {http://dx.doi.org/10.1093/molbev/msp274}}
+	Bdsk-Url-1 = {https://doi.org/10.1093/molbev/msp274}}
 
 
 @inproceedings{hohna2008clock,

--- a/doc/tutorials/STARBEAST/StarBEAST_tutorial.bib
+++ b/doc/tutorials/STARBEAST/StarBEAST_tutorial.bib
@@ -16,7 +16,7 @@
 	Title = {Bayesian inference of species trees from multilocus data},
 	Volume = {27},
 	Year = {2010},
-	Bdsk-Url-1 = {http://dx.doi.org/10.1093/molbev/msp274}}
+	Bdsk-Url-1 = {https://doi.org/10.1093/molbev/msp274}}
 
 
 @article{belfiore2008multilocus,
@@ -49,4 +49,4 @@ and Vaughan, Tim and Wu, Chieh-Hsi and Xie, Dong and Suchard, Marc A and Rambaut
         Title = {BEAST 2: a software platform for Bayesian evolutionary analysis},
         Volume = {10},
         Year = {2014},
-        Bdsk-Url-1 = {http://dx.doi.org/10.1371/journal.pcbi.1003537}}
+        Bdsk-Url-1 = {https://doi.org/10.1371/journal.pcbi.1003537}}

--- a/src/beast/app/DocMaker.java
+++ b/src/beast/app/DocMaker.java
@@ -422,7 +422,7 @@ public class DocMaker {
         for (Citation citation : beastObject.getCitationList()) {
             buf.append("<h2>Reference:</h2><p>" + citation.value() + "</p>\n");
             if (citation.DOI().length() > 0) {
-                buf.append("<p><a href=\"http://dx.doi.org/" + citation.DOI() + "\">doi:" + citation.DOI() + "</a></p>\n");
+                buf.append("<p><a href=\"https://doi.org/" + citation.DOI() + "\">doi:" + citation.DOI() + "</a></p>\n");
             }
         }
 

--- a/src/beast/evolution/speciation/BirthDeathGernhard08Model.java
+++ b/src/beast/evolution/speciation/BirthDeathGernhard08Model.java
@@ -50,7 +50,7 @@ import beast.evolution.tree.TreeInterface;
 
 @Citation(value = "Gernhard 2008. The conditioned reconstructed process. Journal of Theoretical Biology Volume 253, " +
         "Issue 4, 21 August 2008, Pages 769-778",
-        DOI = "doi:10.1016/j.jtbi.2008.04.005", // (http://dx.doi.org/10.1016/j.jtbi.2008.04.005)
+        DOI = "doi:10.1016/j.jtbi.2008.04.005", // (https://doi.org/10.1016/j.jtbi.2008.04.005)
         year = 2008,
         firstAuthorSurname = "gernhard")
 


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). It may be a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old `dx` subdomain is being redirected, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation by applying this update to all static DOI links and the code that generates new DOI links.

Cheers!