### PR TITLE
Added BEASTInterface::notClonable to address #840.

### DIFF
--- a/src/beast/app/beauti/BeautiDoc.java
+++ b/src/beast/app/beauti/BeautiDoc.java
@@ -1769,10 +1769,6 @@ public class BeautiDoc extends BEASTObject implements RequiredInputProvider {
         taboo.add(mcmc);
         // add loggers
         taboo.addAll(mcmc.loggersInput.get());
-        // add exception for *BEAST logger (perhaps need to be generalised?)
-        if (doc.pluginmap.containsKey("SpeciesTreeLoggerX")) {
-            taboo.add(doc.pluginmap.get("SpeciesTreeLoggerX"));
-        }
         // add trees
         for (StateNode node : mcmc.startStateInput.get().stateNodeInput.get()) {
             if (node instanceof Tree) {
@@ -1785,6 +1781,11 @@ public class BeautiDoc extends BEASTObject implements RequiredInputProvider {
             if (o instanceof MRCAPrior) {
                 taboo.add(o);
             }
+        }
+        // add anything else that's marked as unclonable
+        for (BEASTInterface o : doc.pluginmap.values()) {
+            if (o.notCloneable())
+                taboo.add(o);
         }
         if (tabooList != null) {
             taboo.addAll(tabooList);

--- a/src/beast/core/BEASTInterface.java
+++ b/src/beast/core/BEASTInterface.java
@@ -445,7 +445,16 @@ public interface BEASTInterface {
     		}
     	}
     }
-    
+
+    /**
+     * Returns true if the object implementing this interface should
+     * NOT be duplicated by BeautiDoc.deepCopyPlugin().  Used to avoid
+     * unwanted duplication of shared objects by the partition cloning
+     * operation.
+     */
+    default public boolean notCloneable() {
+        return false;
+    }
 }
 
 

--- a/src/beast/evolution/speciation/SpeciesTreeLogger.java
+++ b/src/beast/evolution/speciation/SpeciesTreeLogger.java
@@ -174,4 +174,8 @@ public class SpeciesTreeLogger extends BEASTObject implements Loggable {
         treeInput.get().close(out);
     }
 
+    @Override
+    public boolean notCloneable() {
+        return true;
+    }
 }


### PR DESCRIPTION
This adds the boolean default method notClonable() to BEASTInterface and adds the necessary lines to BeautiDoc.deepCopyPlugin to add objects for which this returns true to the existing set of "taboo" objects.  This is an example solution to the problem referenced in issue #840.