### PR TITLE
Make TreeLikelihood's SubstitutionModel property protected

### DIFF
--- a/src/beast/evolution/likelihood/TreeLikelihood.java
+++ b/src/beast/evolution/likelihood/TreeLikelihood.java
@@ -70,7 +70,7 @@ public class TreeLikelihood extends GenericTreeLikelihood {
      * BEASTObject associated with inputs. Since none of the inputs are StateNodes, it
      * is safe to link to them only once, during initAndValidate.
      */
-    SubstitutionModel substitutionModel;
+    protected SubstitutionModel substitutionModel;
     protected SiteModel.Base m_siteModel;
     protected BranchRateModel.Base branchRateModel;
 


### PR DESCRIPTION
One of the packages I have installed (I forget which one) has a `TreeLikelihood`
subclass that does not live in beast.evolution.likelihood and tripped over this
line. Given what this property does, it looks like it should be protected
anyway, so here is that change.