### PR TITLE
Modified GeneralSubstitutionModel to allow un-normalized rate matrix

### DIFF
--- a/src/beast/evolution/substitutionmodel/GeneralSubstitutionModel.java
+++ b/src/beast/evolution/substitutionmodel/GeneralSubstitutionModel.java
@@ -113,8 +113,7 @@ public class GeneralSubstitutionModel extends SubstitutionModel.Base {
     protected boolean updateMatrix = true;
     private boolean storedUpdateMatrix = true;
 
-    @Override
-    public void getTransitionProbabilities(Node node, double startTime, double endTime, double rate, double[] matrix) {
+    public void getTransitionProbabilities(Node node, double startTime, double endTime, double rate, double[] matrix, boolean normalized) {
         double distance = (startTime - endTime) * rate;
 
         int i, j, k;
@@ -125,7 +124,11 @@ public class GeneralSubstitutionModel extends SubstitutionModel.Base {
         synchronized (this) {
             if (updateMatrix) {
                 setupRelativeRates();
-                setupRateMatrix();
+                if (normalized) {
+                    setupRateMatrix();
+                } else {
+                    setupRateMatrixUnnormalized();
+                }
                 eigenDecomposition = eigenSystem.decomposeMatrix(rateMatrix);
                 updateMatrix = false;
             }
@@ -161,6 +164,13 @@ public class GeneralSubstitutionModel extends SubstitutionModel.Base {
                 u++;
             }
         }
+
+    }
+
+    @Override
+    public void getTransitionProbabilities(Node node, double startTime, double endTime, double rate, double[] matrix) {
+        // get transition probabilities for normalized matrix
+        getTransitionProbabilities(node, startTime, endTime, rate, matrix, true);
     } // getTransitionProbabilities
 
     /**
@@ -219,6 +229,10 @@ public class GeneralSubstitutionModel extends SubstitutionModel.Base {
         }
     } // setupRateMatrix
 
+    /**
+     * sets up un-normalized rate matrix *
+     */
+    protected void setupRateMatrixUnnormalized() {}
 
     /**
      * CalculationNode implementation follows *


### PR DESCRIPTION
The current implementation of GeneralSubstitutionModel assumes the frequencies are specified by the model or calculated from the data. We would like to run substitution models where the frequencies are not user-specified but calculated using matrix exponentiation (i.e. using the getTransitionProbabilities method).