### PR TITLE
Added action+workflow for GH action-based CI.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,16 @@
+name: Unit/integration tests
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: compevol/beast2@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 #   docker run -it -p 5900:5900 beast_testing /bin/bash
 # This will give you a shell in the container. From this
 # shell, run
-#   vncserver $DISPLAY -geometry 1920x1080; ant travis
+#   vncserver $DISPLAY -geometry 1920x1080; ant -f build-testing.xml
 #
 # The previous command exposes the VNC session, so while the
 # BEAUti test suite is running you can run a VNC viewer and
@@ -24,8 +24,6 @@ RUN apt-get update && apt-get install -y ant
 
 # Install and configure VNC server
 RUN apt-get update && apt-get install -y tightvncserver twm
-ENV DISPLAY :0
-ENV USER root
 RUN mkdir /root/.vnc
 RUN echo password | vncpasswd -f > /root/.vnc/passwd
 RUN chmod 600 /root/.vnc/passwd
@@ -37,10 +35,10 @@ RUN cd /root && git clone --branch v3.0.1 --depth=1 https://github.com/beagle-de
 RUN cd /root/beagle-lib && ./autogen.sh && ./configure --prefix=/usr/local && make install
 RUN ldconfig
 
-# Ant build fails if the repo dir isn't named beast2
-RUN mkdir /root/beast2
-WORKDIR /root/beast2
-
 ADD . ./
 
-CMD vncserver $DISPLAY -geometry 1920x1080; ant travis
+CMD export HOME=/root; \
+        export USER=root; \
+        export DISPLAY=:1; \
+        vncserver $DISPLAY -geometry 1920x1080; \
+        ant -f build-testing.xml

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,5 @@
+name: 'Unit Tests'
+description: 'Run unit tests for BDMM-Prime'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/build-testing.xml
+++ b/build-testing.xml
@@ -1,0 +1,153 @@
+<project basedir="." default="test" name="BEAST 2 Unit Tests"
+	xmlns:fx="javafx:com.sun.javafx.tools.ant">
+    <description>
+        Simplified build script for running unit tests only.
+        Not for producing releases.
+    </description>
+
+    <!-- set global properties for this build -->
+    <property name="src" location="src" />
+    <property name="build" location="build" />
+    <property name="lib" location="lib" />
+    <property name="doc" location="doc" />
+    <property name="dist" location="build/dist" />
+    <property name="test" location="test" />
+
+    <property name="main_class_BEASTLauncher" value="beast.app.beastapp.BeastLauncher" />
+    <property name="report" value="build/junitreport" />
+
+    <path id="classpath">
+        <fileset dir="${lib}" includes="beagle.jar"/>
+        <fileset dir="${lib}" includes="jam.jar"/>
+        <fileset dir="${lib}" includes="colt.jar"/>
+        <fileset dir="${lib}" includes="fest.jar"/>
+        <fileset dir="${lib}" includes="junit-4.8.2.jar"/>
+        <fileset dir="${lib}" includes="antlr-runtime-4.7.jar"/>
+    </path>
+
+    <target name="init">
+        <echo message="${ant.project.name}: ${ant.file}" />
+    </target>
+
+    <target name="clean">
+        <delete dir="${build}" />
+        <delete dir="${test}" />
+    </target>
+
+    <!-- compile Java source code -->
+    <target name="compile-all" depends="init">
+        <echo>Building BEAST 2</echo>
+        <mkdir dir="${build}" />
+
+        <!-- Compile the java code from ${src} into ${build} /bin -->
+        <javac source="1.8"
+		target="1.8"
+		bootclasspath='/opt/jdk1.8.0_131/jre/lib/rt.jar'
+               srcdir="${src}"
+               destdir="${build}"
+               classpathref="classpath"
+               fork="true"
+               memoryinitialsize="256m"
+               memorymaximumsize="1024m"
+               includeAntRuntime='false'>
+            <include name="beast/**/**" />
+            <!-- apache commons math -->
+            <include name="org/**/**" />
+            <!-- compile JUnit test classes -->
+            <include name="test/beast/**" />
+        </javac>
+
+        <echo message="Ant running on Java version ${ant.java.version}"/>
+
+        <!-- compile the launcher apps against Java 6-->
+        <delete file="${build}/beast/app/beauti/BeautiLauncher.class" />
+        <delete file="${build}/beast/app/tools/AppLauncherLauncher.class" />
+        <delete file="${build}/beast/app/tools/LogCombinerLauncher.class" />
+        <delete file="${build}/beast/app/treeannotator/TreeAnnotatorLauncher.class" />
+        <delete file="${build}/beast/app/util/Utils6.class" />
+        <delete file="${build}/beast/app/BEASTVersion.class" />
+        <delete file="${build}/beast/util/BEASTClassLoader.class" />
+        <delete>
+	      <fileset dir="${build}/beast/core/util/" includes="Log*.class" />
+    	  <fileset dir="${build}/beast/app/beastapp/" includes="BeastLauncher*.class" />
+	      <fileset dir="${build}/beast/app/util/" includes="Arguments*.class"/>
+	      <fileset dir="${build}/beast/util/" includes="Package*.class"/>
+    	</delete>
+        <delete file="${build}/beast/app/util/Version.class" />
+        <javac source="1.6"
+               target="1.6"
+               bootclasspath='/opt/jdk1.6.0_45/jre/lib/rt.jar'
+               srcdir="${src}"
+               destdir="${build}"
+               classpathref="classpath"
+               fork="true"
+               memoryinitialsize="256m"
+               memorymaximumsize="1024m"
+               includeAntRuntime='false'>
+            <include name="beast/**/*Launcher.java" />
+            <include name="beast/**/Utils6.java" />
+            <include name="beast/**/BEASTVersion.java" />
+            <include name="beast/**/Version.java" />
+            <include name="beast/util/Package*.java" />
+            <include name="beast/app/util/Arguments.java" />
+            <include name="beast/core/util/Log.java" />
+	    <include name="beast/util/BEASTClassLoader.java" />
+        </javac>
+        <copy todir="${build}">
+            <fileset dir="${src}" includes="**/*.properties" />
+            <fileset dir="${src}" includes="**/*.png" />
+        </copy>
+        <echo message="Successfully compiled." />
+    </target>
+
+    <!-- Core BEAST unit tests -->
+    <target name="junit">
+        <mkdir dir="${report}" />
+        <junit printsummary="yes" failureproperty="junitfailed">
+            <!--showoutput='yes'-->
+            <classpath>
+                <path refid="classpath" />
+                <path location="${build}" />
+            </classpath>
+
+            <formatter type="xml" />
+
+            <batchtest fork="yes" todir="${report}">
+                <fileset dir="${src}">
+                    <include name="test/**/*Test.java" />
+                    <exclude name="test/beast/beast2vs1/**/*Test.java"/>
+                    <exclude name="test/beast/app/beauti/**/*Test.java"/>
+                </fileset>
+            </batchtest>
+        </junit>
+        <echo message="JUnit test finished." />
+    </target>
+
+    <!-- BEAUti UI unit tests -->
+    <target name="junitb">
+        <mkdir dir="${report}" />
+        <junit printsummary="yes" failureproperty="junitbfailed" maxmemory="4G">
+            <!--showoutput='yes'-->
+            <classpath>
+                <path refid="classpath" />
+                <path location="${build}" />
+            </classpath>
+
+            <formatter type="xml" />
+
+            <batchtest fork="yes" todir="${report}">
+                <fileset dir="${src}">
+                    <include name="test/beast/app/beauti/**/*Test.java"/>
+                </fileset>
+            </batchtest>
+        </junit>
+        <echo message="JUnit test finished." />
+    </target>
+
+    <!-- Target for Travis-CI with non-zero exit status on test failure. -->
+    <target name="test" depends="clean, compile-all, junit, junitb">
+        <fail if="junitfailed" message="One or more CORE BEAST tests failed."/>
+        <fail if="junitbfailed" message="One or more BEAUTI tests failed."/>
+    </target>
+
+  </project>


### PR DESCRIPTION
Travis-CI is essentially [ending their free tier](https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing) that we have used for the last few years to run beast2 unit tests.  See [here](https://www.jeffgeerling.com/blog/2020/travis-cis-new-pricing-plan-threw-wrench-my-open-source-works) for some background.

I've taken the liberty of porting our test suite over to Github Actions.  This was mostly straight-forward, with the following two exceptions:

1. I wound up having to create a new build script, build-testing.xml, to house the task definitions run by Actions.  This was because the presence of JSign in the original script was producing "class not found" errors that I wasn't able to diagnose.  It's probably a good thing to split the testing build script off at this point anyway, as the original build script is getting quite big.

2. The specific way Actions runs docker did cause some problems, and addressing these required a couple of changes in the Dockerfile.  This was a bit of a headache to get right, as it had to do with the portion of the Dockerfile responsible for setting up and running the VNC server required for the BEAUti tests.  These changes hopefully shouldn't affect anybody's ability to build and run the test container locally; at least it still runs fine on my machine. 

If we merge this, I can update the badge in the README to give the testing status based on the Actions result instead of Travis.