### PR TITLE
Fixed issue in UpDownOperator

### DIFF
--- a/src/beast/evolution/operators/UpDownOperator.java
+++ b/src/beast/evolution/operators/UpDownOperator.java
@@ -86,7 +86,7 @@ public class UpDownOperator extends Operator {
             for (StateNode up : upInput.get()) {
                 if (up instanceof RealParameter) {
                     RealParameter p = (RealParameter) up;
-                    p.setValue(p.getValue(index) * scale);
+                    p.setValue(index, p.getValue(index) * scale);
                 }
                 if (outsideBounds(up)) {
                     return Double.NEGATIVE_INFINITY;
@@ -96,7 +96,7 @@ public class UpDownOperator extends Operator {
             for (StateNode down : downInput.get()) {
                 if (down instanceof RealParameter) {
                     RealParameter p = (RealParameter) down;
-                    p.setValue(p.getValue(index) / scale);
+                    p.setValue(index, p.getValue(index) / scale);
                 }
                 if (outsideBounds(down)) {
                     return Double.NEGATIVE_INFINITY;


### PR DESCRIPTION
UpDownOperator was always changing elements with index=0 of multidimensional parameters if elementWise=true. Fixed by providing an index of the element to be scaled and replaced when calling p.setValue method.