### PR TITLE
Make clock rate function

### DIFF
--- a/src/beast/app/beauti/BeautiDoc.java
+++ b/src/beast/app/beauti/BeautiDoc.java
@@ -52,6 +52,7 @@ import beast.core.BEASTInterface;
 import beast.core.BEASTObject;
 import beast.core.Description;
 import beast.core.Distribution;
+import beast.core.Function;
 import beast.core.Input;
 import beast.core.Input.Validate;
 import beast.core.MCMC;

--- a/src/beast/app/beauti/BeautiDoc.java
+++ b/src/beast/app/beauti/BeautiDoc.java
@@ -1360,15 +1360,18 @@ public class BeautiDoc extends BEASTObject implements RequiredInputProvider {
                         }
                     }
                     BranchRateModel.Base model = treeLikelihood.branchRateModelInput.get();
-                    if (model != null) {
-                        RealParameter clockRate = model.meanRateInput.get();
-                        clockRate.isEstimatedInput.setValue(needsEstimation, clockRate);
-                        if (firstClock == null) {
-                            firstClock = clockRate;
-                        }
-                    }
-                    i++;
-                }
+					if (model != null) {
+						if (model.meanRateInput.get() instanceof RealParameter) {
+							RealParameter clockRate = (RealParameter) model.meanRateInput.get();
+
+							clockRate.isEstimatedInput.setValue(needsEstimation, clockRate);
+							if (firstClock == null) {
+								firstClock = clockRate;
+							}
+						}
+					}
+					i++;
+				}
             }
         }
     }

--- a/src/beast/app/beauti/ClockModelListInputEditor.java
+++ b/src/beast/app/beauti/ClockModelListInputEditor.java
@@ -12,6 +12,7 @@ import javax.swing.JTextField;
 import beast.app.draw.ListInputEditor;
 import beast.app.draw.SmallLabel;
 import beast.core.BEASTInterface;
+import beast.core.Function;
 import beast.core.Input;
 import beast.core.MCMC;
 import beast.core.Operator;
@@ -120,20 +121,22 @@ public class ClockModelListInputEditor extends ListInputEditor {
 	    		Alignment data = doc.alignments.get(i); 
 	    		int weight = data.getSiteCount();
 	    		BranchRateModel.Base clockModel = (BranchRateModel.Base) doc.clockModels.get(i);
-	    		RealParameter clockRate = clockModel.meanRateInput.get();
-	    		//clockRate.m_bIsEstimated.setValue(true, clockRate);
-	    		if (clockRate.isEstimatedInput.get()) {
-	    			if (commonClockRate < 0) {
-	    				commonClockRate = clockRate.valuesInput.get().get(0);
-	    			} else {
-	    				if (Math.abs(commonClockRate - clockRate.valuesInput.get().get(0)) > 1e-10) {
-	    					isAllClocksAreEqual = false;
-	    				}
-	    			}
-    				weights += weight + " ";
-	    			parameters.add(clockRate);
-	    		}
-	    		//doc.autoSetClockRate = false;
+				if (clockModel.meanRateInput.get() instanceof RealParameter) {
+					RealParameter clockRate = (RealParameter) clockModel.meanRateInput.get();
+					// clockRate.m_bIsEstimated.setValue(true, clockRate);
+					if (clockRate.isEstimatedInput.get()) {
+						if (commonClockRate < 0) {
+							commonClockRate = clockRate.valuesInput.get().get(0);
+						} else {
+							if (Math.abs(commonClockRate - clockRate.valuesInput.get().get(0)) > 1e-10) {
+								isAllClocksAreEqual = false;
+							}
+						}
+						weights += weight + " ";
+						parameters.add(clockRate);
+					}
+					// doc.autoSetClockRate = false;
+				}
 	    	}
 	    	if (!fixMeanRatesCheckBox.isSelected()) {
 	    		fixMeanRatesValidateLabel.setVisible(false);

--- a/src/beast/evolution/branchratemodel/BranchRateModel.java
+++ b/src/beast/evolution/branchratemodel/BranchRateModel.java
@@ -2,8 +2,9 @@ package beast.evolution.branchratemodel;
 
 import beast.core.CalculationNode;
 import beast.core.Description;
+import beast.core.Function;
 import beast.core.Input;
-import beast.core.parameter.RealParameter;
+import beast.core.Function;
 import beast.evolution.tree.Node;
 
 /**
@@ -16,7 +17,7 @@ public interface BranchRateModel {
 
     @Description(value = "Base implementation of a clock model.", isInheritable = false)
     public abstract class Base extends CalculationNode implements BranchRateModel {
-        final public Input<RealParameter> meanRateInput = new Input<>("clock.rate", "mean clock rate (defaults to 1.0)");
+        final public Input<Function> meanRateInput = new Input<>("clock.rate", "mean clock rate (defaults to 1.0)");
 
         // empty at the moment but brings together the required interfaces
     }

--- a/src/beast/evolution/branchratemodel/RandomLocalClockModel.java
+++ b/src/beast/evolution/branchratemodel/RandomLocalClockModel.java
@@ -2,6 +2,7 @@ package beast.evolution.branchratemodel;
 
 import beast.core.Citation;
 import beast.core.Description;
+import beast.core.Function;
 import beast.core.Input;
 import beast.core.parameter.BooleanParameter;
 import beast.core.parameter.RealParameter;
@@ -44,7 +45,7 @@ public class RandomLocalClockModel extends BranchRateModel.Base {
                     false, Input.Validate.OPTIONAL);
 
     Tree tree;
-    RealParameter meanRate;
+    protected Function meanRate;
     boolean scaling = true;
 
     @Override
@@ -145,7 +146,7 @@ public class RandomLocalClockModel extends BranchRateModel.Base {
 
             scaleFactor = timeTotal / branchTotal;
 
-            scaleFactor *= meanRate.getValue();
+            scaleFactor *= meanRate.getArrayValue();
         } else {
             scaleFactor = 1.0;
         }

--- a/src/beast/evolution/branchratemodel/StrictClockModel.java
+++ b/src/beast/evolution/branchratemodel/StrictClockModel.java
@@ -1,6 +1,7 @@
 package beast.evolution.branchratemodel;
 
 import beast.core.Description;
+import beast.core.Function;
 import beast.core.parameter.RealParameter;
 import beast.evolution.tree.Node;
 
@@ -11,41 +12,47 @@ import beast.evolution.tree.Node;
 @Description("Defines a mean rate for each branch in the beast.tree.")
 public class StrictClockModel extends BranchRateModel.Base {
 
-    //public Input<RealParameter> muParameterInput = new Input<>("clock.rate", "the clock rate (defaults to 1.0)");
+	// public Input<RealParameter> muParameterInput = new Input<>("clock.rate", "the
+	// clock rate (defaults to 1.0)");
 
-    RealParameter muParameter;
+	protected Function muSource;
+	private double mu = 1.0;
 
-    @Override
-    public void initAndValidate() {
-        muParameter = meanRateInput.get();
-        if (muParameter != null) {
-            muParameter.setBounds(Math.max(0.0, muParameter.getLower()), muParameter.getUpper());
-            mu = muParameter.getValue();
-        }
-    }
+	@Override
+	public void initAndValidate() {
+		if (meanRateInput.get() != null) {
+			muSource = meanRateInput.get();
+			try {
+				RealParameter muParameter = (RealParameter) muSource;
+				muParameter.setBounds(Math.max(0.0, muParameter.getLower()), muParameter.getUpper());
+			} catch (ClassCastException t) {
+				// Nothing
+			}
+			mu = muSource.getArrayValue();
+		}
+	}
 
-    @Override
-    public double getRateForBranch(final Node node) {
-        return mu;
-    }
+	@Override
+	public double getRateForBranch(final Node node) {
+		return mu;
+	}
 
-    @Override
-    public boolean requiresRecalculation() {
-        mu = muParameter.getValue();
-        return true;
-    }
+	@Override
+	public boolean requiresRecalculation() {
+		mu = muSource.getArrayValue();
+		return true;
+	}
 
-    @Override
-    protected void restore() {
-        mu = muParameter.getValue();
-        super.restore();
-    }
+	@Override
+	protected void restore() {
+		mu = muSource.getArrayValue();
+		super.restore();
+	}
 
-    @Override
-    protected void store() {
-        mu = muParameter.getValue();
-        super.store();
-    }
+	@Override
+	protected void store() {
+		mu = muSource.getArrayValue();
+		super.store();
+	}
 
-    private double mu = 1.0;
 }

--- a/src/beast/evolution/branchratemodel/StrictClockModel.java
+++ b/src/beast/evolution/branchratemodel/StrictClockModel.java
@@ -12,47 +12,45 @@ import beast.evolution.tree.Node;
 @Description("Defines a mean rate for each branch in the beast.tree.")
 public class StrictClockModel extends BranchRateModel.Base {
 
-	// public Input<RealParameter> muParameterInput = new Input<>("clock.rate", "the
-	// clock rate (defaults to 1.0)");
+    // public Input<RealParameter> muParameterInput = new Input<>("clock.rate", "the
+    // clock rate (defaults to 1.0)");
 
-	protected Function muSource;
-	private double mu = 1.0;
+    protected Function muSource;
+    private double mu = 1.0;
 
-	@Override
-	public void initAndValidate() {
-		if (meanRateInput.get() != null) {
-			muSource = meanRateInput.get();
-			try {
-				RealParameter muParameter = (RealParameter) muSource;
-				muParameter.setBounds(Math.max(0.0, muParameter.getLower()), muParameter.getUpper());
-			} catch (ClassCastException t) {
-				// Nothing
-			}
-			mu = muSource.getArrayValue();
-		}
-	}
+    @Override
+    public void initAndValidate() {
+        if (meanRateInput.get() != null) {
+            muSource = meanRateInput.get();
+            if (muSource instanceof RealParameter) {
+                RealParameter muParameter = (RealParameter) muSource;
+                muParameter.setBounds(Math.max(0.0, muParameter.getLower()), muParameter.getUpper());
+            }
+            mu = muSource.getArrayValue();
+        }
+    }
 
-	@Override
-	public double getRateForBranch(final Node node) {
-		return mu;
-	}
+    @Override
+    public double getRateForBranch(final Node node) {
+        return mu;
+    }
 
-	@Override
-	public boolean requiresRecalculation() {
-		mu = muSource.getArrayValue();
-		return true;
-	}
+    @Override
+    public boolean requiresRecalculation() {
+        mu = muSource.getArrayValue();
+        return true;
+    }
 
-	@Override
-	protected void restore() {
-		mu = muSource.getArrayValue();
-		super.restore();
-	}
+    @Override
+    protected void restore() {
+        mu = muSource.getArrayValue();
+        super.restore();
+    }
 
-	@Override
-	protected void store() {
-		mu = muSource.getArrayValue();
-		super.store();
-	}
+    @Override
+    protected void store() {
+        mu = muSource.getArrayValue();
+        super.store();
+    }
 
 }

--- a/src/beast/evolution/branchratemodel/UCRelaxedClockModel.java
+++ b/src/beast/evolution/branchratemodel/UCRelaxedClockModel.java
@@ -6,8 +6,10 @@ import java.util.Arrays;
 
 import org.apache.commons.math.MathException;
 
+import beast.core.CalculationNode;
 import beast.core.Citation;
 import beast.core.Description;
+import beast.core.Function;
 import beast.core.Input;
 import beast.core.parameter.IntegerParameter;
 import beast.core.parameter.RealParameter;
@@ -54,7 +56,7 @@ public class UCRelaxedClockModel extends BranchRateModel.Base {
 
     ParametricDistribution distribution; //the distribution of the rates
 
-    RealParameter meanRate;
+    Function meanRate;
     Tree tree;
     private int branchCount;//the number of branches of the tree
     private boolean normalize = false;//
@@ -212,7 +214,7 @@ public class UCRelaxedClockModel extends BranchRateModel.Base {
             }
             renormalize = false;
         }
-        return getRawRate(node) * scaleFactor * meanRate.getValue();
+        return getRawRate(node) * scaleFactor * meanRate.getArrayValue();
     }
 
     /**
@@ -365,11 +367,14 @@ public class UCRelaxedClockModel extends BranchRateModel.Base {
         if (rateInput.get() != null && rateInput.get().somethingIsDirty()) {
             return true;
         }
-        if (meanRate.somethingIsDirty()) {
-            return true;
+        
+        if (meanRate instanceof RealParameter) {
+        	return ((RealParameter) meanRate).somethingIsDirty() || recompute;
+        } else if (meanRate instanceof CalculationNode) {
+        	return ((CalculationNode) meanRate).isDirtyCalculation() || recompute;
+        } else {
+        	return recompute;
         }
-
-        return recompute;
     }
 
     @Override


### PR DESCRIPTION
Sometimes, it's useful to compute clock rates from other inputs, using eg. the expression calculatiors in BEAST or feast. (In my particular use case, I know the substitution rate 1→0 in an ascertained binary model, so I need to derive it from the inferred frequency of 0s.) There are very few locations in the BEAST code that actually rely on clock rates being parameters, instead of more generic Function objects, so this small patch makes the behaviour more generic, but keeps those things in place by explicit isinstance tests. It should therefore be backwards compatible.