### PR TITLE
Added checksum-based validity checks for store/restore issues

### DIFF
--- a/src/beast/core/CalculationNode.java
+++ b/src/beast/core/CalculationNode.java
@@ -126,4 +126,37 @@ public abstract class CalculationNode extends BEASTObject {
      */
     private boolean isDirty = false;
 
+    /**
+     * Compute a checksum of this calculation node. Checksums are used for validity checks, to ensure
+     * that state nodes and fat calculation nodes are correctly restored. The base implementation will
+     * never trigger the validity checks and must be overwritten to make use of them. Lean calculation
+     * nodes should NOT overwrite this method, as they do not need to be restored and hence checksum
+     * comparisons could lead to false alarms.
+     *
+     * @return checksum of the calculation node
+     */
+    protected int getChecksum() {
+        return 0;
+    }
+
+    /**
+     * The checksum of the calculation node, evaluated and stored before an operator proposes an MCMC step.
+     */
+    protected int preOperatorChecksum;
+
+    /**
+     * Store the current checksum as the ´preOperatorChecksum´.
+     */
+    public void storeChecksum() {
+        preOperatorChecksum = getChecksum();
+    }
+
+    /**
+     * Check whether the current checksum matches the ´preOperatorChecksum´.
+     * @return true iff the checksums match
+     */
+    public boolean matchesOldChecksum() {
+        return preOperatorChecksum == getChecksum();
+    }
+
 } // class CalculationNode

--- a/src/beast/core/State.java
+++ b/src/beast/core/State.java
@@ -536,7 +536,7 @@ public class State extends BEASTObject {
     /**
      * return current set of calculation nodes based on the set of StateNodes that have changed *
      */
-    private List<CalculationNode> getCurrentCalculationNodes() {
+    public List<CalculationNode> getCurrentCalculationNodes() {
         List<CalculationNode> calcNodes = trie.get(nrOfChangedStateNodes);
         if (calcNodes != null) {
             // the list is pre-calculated


### PR DESCRIPTION
When working on a BEAST2 package, I noticed that caching bugs were among the most difficult to find and cost me a lot of time. Hence, I added some additional checks in the MCMC class, which helped me to debug my code. The idea is simple: 

1. At the start of an iteration of the MCMC, we store a checksum of each calculationNode
2. If the step is rejected, we check whether all the checksums are equal to the stored ones.

If the checksums are not the same, clearly something went wrong when trying to restore the previous state and we throw an exception. There are (at least) two reasons why this might happen:

* The store/restore methods are incorrect or missing.
* A fat CalculationNode was changed in an operator proposal, before "store" is called (this was particularly tough to find).

In the current implementation the checksum method defaults to returning a constant 0, which means no exceptions will be thrown. Furthermore the checks are only performed when the debugFlag is set. Hence, this commit will not interfere with any existing analyses. BEAST2 developers who want to use the checks can override the getChecksum() method for the StateNodes and fat CalculationNodes they want to check. I give two example implementations below:

**Tree checksum:**
As a simple checksum for the Tree class we could take a hash value of the root height:
```
    @Override
    public int getChecksum() {
        return Double.hashCode(getRoot().getHeight());
    }
```
However, bugs that don't affect the root height could still slip through and we could make the test more elaborate by hashing all heights and information about the topology as well.

**TreeLikelihood checksum:**
In the case of the tree likelihood we can simply use a hash value of getCurrentLogP() as a checksum:
```
    @Override
    public int getChecksum() {
        return Double.hashCode(getCurrentLogP());
    }
```
