### PR TITLE
Initialise hs to correct dimensions

### DIFF
--- a/src/beast/app/treeannotator/TreeAnnotator.java
+++ b/src/beast/app/treeannotator/TreeAnnotator.java
@@ -1564,7 +1564,7 @@ public class TreeAnnotator {
         cladeSystem.getTreeCladeCodes(targetTree, ctarget);
 
         // temp collecting heights inside loop allocated once
-        double[][] hs = new double[clades][treeSet.totalTrees];
+        double[][] hs = new double[clades][treeSet.totalTrees - treeSet.burninCount];
 
         // heights total sum from posterior trees
         double[] ths = new double[clades];


### PR DESCRIPTION
When TreeAnnotator is run with the -heights option set to "ca" and -burnin set to some non-zero value, estimates of CAheights_95%HPD become distorted and would always include 0 when the burnin percentage is sufficiently large (> 10%).

The reason for this seems to be that totalTrees in the TreeSet class does not account for trees that are discarded as burnin, resulting in the heights collecting variable hs being initialised to the wrong length. The excess zeroes (due to trees being discarded as burnin) resulted in the CAheight_95%HPD being wrongly estimated by annotateHPDAttribute.