### PR TITLE
Fix bug in Nucleotide isAmbiguousCode

### DIFF
--- a/src/beast/evolution/datatype/Nucleotide.java
+++ b/src/beast/evolution/datatype/Nucleotide.java
@@ -35,6 +35,13 @@ public class Nucleotide extends Base {
     }
 
     @Override
+    public boolean isAmbiguousCode(int code) {
+        int[] states = getStatesForCode(code);
+        boolean isAmbiguous = states.length > 1;
+        return isAmbiguous;
+    }
+
+    @Override
     public String getTypeDescription() {
         return "nucleotide";
     }


### PR DESCRIPTION
The `isAmbiguousCode(int code)` method returns true for the Uracil (U) in the Nucleotide datatype. 
U is mapped as state code 4, stateCount = 4,  which breaks the assumption from DataType.Base that `(code < 0 || code >= stateCount)` are ambiguous states.

I added a method `isAmbiguousCode(int code)` to override default implementation. It now checks if the code represents more than one state, i.e. code is ambiguous if `getStatesForCode(code).length > 1`.

@alexeid @walterxie could you check if these changes are ok?