### PR TITLE
Moved ambiguity fix to DataType Base class

### DIFF
--- a/src/beast/evolution/datatype/DataType.java
+++ b/src/beast/evolution/datatype/DataType.java
@@ -373,7 +373,9 @@ public interface DataType {
 
 		@Override
 		public boolean isAmbiguousCode(int code) {
-			return (code < 0 || code >= stateCount);
+			int[] states = getStatesForCode(code);
+			boolean isAmbiguous = states.length > 1;
+			return isAmbiguous;
 		}
 
 		@Override

--- a/src/beast/evolution/datatype/Nucleotide.java
+++ b/src/beast/evolution/datatype/Nucleotide.java
@@ -35,13 +35,6 @@ public class Nucleotide extends Base {
     }
 
     @Override
-    public boolean isAmbiguousCode(int code) {
-        int[] states = getStatesForCode(code);
-        boolean isAmbiguous = states.length > 1;
-        return isAmbiguous;
-    }
-
-    @Override
     public String getTypeDescription() {
         return "nucleotide";
     }


### PR DESCRIPTION
Moved ambiguity fix from Nucleotide class to the DataType Base class 

@tgvaughan @rbouckaert 