### PR TITLE
Fix bug where processDefaultValues reads past the first '='

### DIFF
--- a/src/beast/util/XMLParser.java
+++ b/src/beast/util/XMLParser.java
@@ -370,7 +370,7 @@ public class XMLParser {
     			int j = i + 1;
     			int k = -1;
     			while (j < xml.length() && xml.charAt(j) != ')') {
-    				if (xml.charAt(j) == '=') {
+    				if (xml.charAt(j) == '=' && k > 0) {
     					k = j;
     				}
     				j++;

--- a/src/beast/util/XMLParser.java
+++ b/src/beast/util/XMLParser.java
@@ -370,7 +370,7 @@ public class XMLParser {
     			int j = i + 1;
     			int k = -1;
     			while (j < xml.length() && xml.charAt(j) != ')') {
-    				if (xml.charAt(j) == '=' && k > 0) {
+    				if (xml.charAt(j) == '=' && k < 0) {
     					k = j;
     				}
     				j++;


### PR DESCRIPTION
If traits defaults are specified by the user in the form `value="$(dateTrait.value=68BO_2011.0=2011.0,65BO_2013.0=2013.0,97SGR_2012.0=2012.0..."` BEAST would read past the first '=' to the last '='. This makes the parserDefinitions key equal "dateTrait.value=68BO_2011.0=2011.0,65BO_2013.0=2013.0,97SGR_2012.0" and value "2012.0". I fixed this by only setting k to the index of the first '='.