### PR TITLE
Remove '/' from stateFileName prefix

### DIFF
--- a/src/beast/core/Runnable.java
+++ b/src/beast/core/Runnable.java
@@ -20,7 +20,7 @@ public abstract class Runnable extends BEASTObject {
     		stateFileName = System.getProperty("state.file.name");
     	} else {
             if (System.getProperty("file.name.prefix") != null) {
-            	stateFileName = System.getProperty("file.name.prefix") + "/" + fileName;
+            	stateFileName = System.getProperty("file.name.prefix") + fileName;
             } else {
             	stateFileName = fileName;
             }


### PR DESCRIPTION
When the user specifics a file.name.prefix with the `-prefix` option the logfiles are simply concatenated i.e. https://github.com/CompEvol/beast2/blob/4d95f0095d20a6999d2757299c629bfbbf14b94b/src/beast/core/Logger.java#L367 However, the stateFileName includes a '/' i.e. `stateFileName = System.getProperty("file.name.prefix") + "/" + fileName`. This means that the state file prefix is treated as a folder. I fixed this by removing the '/' from stateFileName to make it consistent with the fileName prefix format.