### PR TITLE
Reduce the binary tree assumptions

### DIFF
--- a/src/beast/app/seqgen/SequenceSimulator.java
+++ b/src/beast/app/seqgen/SequenceSimulator.java
@@ -187,8 +187,8 @@ public class SequenceSimulator extends beast.core.Runnable {
      * @
      */
     void traverse(Node node, int[] parentSequence, int[] category, Alignment alignment)  {
-        for (int childIndex = 0; childIndex < 2; childIndex++) {
-            Node child = (childIndex == 0 ? node.getLeft() : node.getRight());
+        for (int childIndex = 0; childIndex < node.getChildCount(); childIndex++) {
+            Node child = node.getChild(childIndex);
             for (int i = 0; i < m_categoryCount; i++) {
                 getTransitionProbabilities(m_tree, child, i, m_probabilities[i]);
             }

--- a/src/beast/app/seqgen/SimulatedAlignment.java
+++ b/src/beast/app/seqgen/SimulatedAlignment.java
@@ -169,8 +169,8 @@ public class SimulatedAlignment extends Alignment {
      * @param alignment
      */
     void traverse(Node node, int[] parentSequence, int[] category) {
-        for (int childIndex = 0; childIndex < 2; childIndex++) {
-            Node child = (childIndex == 0 ? node.getLeft() : node.getRight());
+        for (int childIndex = 0; childIndex < node.getChildCount(); childIndex++) {
+            Node child = node.getChild(childIndex);
             for (int i = 0; i < m_categoryCount; i++) {
                 getTransitionProbabilities(m_tree, child, i, m_probabilities[i]);
             }

--- a/src/beast/app/treeannotator/TreeSetParser.java
+++ b/src/beast/app/treeannotator/TreeSetParser.java
@@ -292,11 +292,8 @@ public class TreeSetParser {
 
 	/** move y-position of a tree with offset f **/
 	public void offsetHeight(Node node, double f) {
-		if (!node.isLeaf()) {
-			offsetHeight(node.getLeft(), f);
-			if (node.getRight() != null) {
-				offsetHeight(node.getRight(), f);
-			}
+		for (Node child: node.getChildren()) {
+			offsetHeight(child, f);
 		}
 		node.setHeight(node.getHeight() + f);
 	}
@@ -312,9 +309,8 @@ public class TreeSetParser {
 		} else {
 			double posY = offSet + node.getHeight();
 			double yMax = 0;
-			yMax = Math.max(yMax, lengthToHeight(node.getLeft(), posY));
-			if (node.getRight() != null) {
-				yMax = Math.max(yMax, lengthToHeight(node.getRight(), posY));
+			for (Node child: node.getChildren()) {
+				yMax = Math.max(yMax, lengthToHeight(child, posY));				
 			}
 			node.setHeight(-posY);
 			return yMax;
@@ -357,14 +353,14 @@ public class TreeSetParser {
 	}
 	
 
-	 double height(Node node) {
-		 if (node.isLeaf()) {
-			 return node.getLength();
-		 } else {
-			 return node.getLength() + Math.max(height(node.getLeft()), height(node.getRight()));
-		 }
-	 }
-	 
+	double height(Node node) {
+		double height = 0.0;
+		for (Node child : node.getChildren()) {
+			height = Math.max(height(child), height);
+		}
+		return node.getLength() + height;
+	}
+ 
 	 char [] m_chars;
 	 int m_iTokenStart;
 	 int m_iTokenEnd;
@@ -464,11 +460,10 @@ public class TreeSetParser {
 						isFirstChild.remove(isFirstChild.size()-1);
 						Node dummyparent = new Node();
 						dummyparent.setHeight(DEFAULT_LENGTH);
-						dummyparent.setLeft(left);
+						dummyparent.setChild(0, left);
 						left.setParent(dummyparent);
-						dummyparent.setRight(null);
 						Node parent = stack.lastElement();
-						parent.setLeft(left);
+						parent.setChild(0, left);
 						left.setParent(parent);
 						String metaData = metaDataString.remove(metaDataString.size() - 1);
 						left.metaDataString = metaData;
@@ -489,9 +484,9 @@ public class TreeSetParser {
 					isFirstChild.remove(isFirstChild.size()-1);
 					Node dummyparent = new Node();
 					dummyparent.setHeight(DEFAULT_LENGTH);
-					dummyparent.setLeft(left);
+					dummyparent.setChild(0, left);
 					left.setParent (dummyparent);
-					dummyparent.setRight(right);
+					dummyparent.setChild(1, right);
 					right.setParent(dummyparent);
 					stack.add(dummyparent);
 					isFirstChild.add(false);
@@ -512,9 +507,9 @@ public class TreeSetParser {
 				parseMetaData(left, metaData);
 
 				Node parent = stack.lastElement();
-				parent.setLeft(left);
+				parent.setChild(0, left);
 				left.setParent(parent);
-				parent.setRight(right);
+				parent.setChild(1, right);
 				right.setParent(parent);
 				metaData = metaDataString.lastElement();
 				parseMetaData(parent, metaData);

--- a/src/beast/evolution/branchratemodel/RandomLocalClockModel.java
+++ b/src/beast/evolution/branchratemodel/RandomLocalClockModel.java
@@ -110,9 +110,8 @@ public class RandomLocalClockModel extends BranchRateModel.Base {
         }
         unscaledBranchRates[nodeNumber] = rate;
 
-        if (!node.isLeaf()) {
-            calculateUnscaledBranchRates(node.getLeft(), rate, indicators, rates);
-            calculateUnscaledBranchRates(node.getRight(), rate, indicators, rates);
+        for (Node child: node.getChildren()) {
+            calculateUnscaledBranchRates(child, rate, indicators, rates);
         }
     }
 

--- a/src/beast/evolution/likelihood/BeagleTreeLikelihood.java
+++ b/src/beast/evolution/likelihood/BeagleTreeLikelihood.java
@@ -956,19 +956,16 @@ public class BeagleTreeLikelihood extends TreeLikelihood {
         }
 
         // If the node is internal, update the partial likelihoods.
-        if (!node.isLeaf()) {
+		if (!node.isLeaf()) {
+			int updateChild = Tree.IS_CLEAN;
+			for (Node child : node.getChildren()) {
+				// Traverse down the two child nodes
+				final int[] op1 = { -1 };
+				updateChild |= traverse(child, op1, flip);
+			}
 
-            // Traverse down the two child nodes
-            Node child1 = node.getLeft();
-            final int[] op1 = {-1};
-            final int update1 = traverse(child1, op1, flip);
-
-            Node child2 = node.getRight();
-            final int[] op2 = {-1};
-            final int update2 = traverse(child2, op2, flip);
-
-            // If either child node was updated then update this node too
-            if (update1 != Tree.IS_CLEAN || update2 != Tree.IS_CLEAN) {
+			// If either child node was updated then update this node too
+			if (updateChild != Tree.IS_CLEAN) {
 
                 int x = operationCount[operationListCount] * Beagle.OPERATION_TUPLE_SIZE;
 
@@ -1009,14 +1006,17 @@ public class BeagleTreeLikelihood extends TreeLikelihood {
                     operations[x + 2] = Beagle.NONE;
                 }
 
-                operations[x + 3] = partialBufferHelper.getOffsetIndex(child1.getNr()); // source node 1
-                operations[x + 4] = matrixBufferHelper.getOffsetIndex(child1.getNr()); // source matrix 1
-                operations[x + 5] = partialBufferHelper.getOffsetIndex(child2.getNr()); // source node 2
-                operations[x + 6] = matrixBufferHelper.getOffsetIndex(child2.getNr()); // source matrix 2
+                int x_offset = 3;
+				for (Node child : node.getChildren()) {
+					operations[x + x_offset] = partialBufferHelper.getOffsetIndex(child.getNr()); // source node
+					x_offset++;
+					operations[x + x_offset] = matrixBufferHelper.getOffsetIndex(child.getNr()); // source matrix 1
+					x_offset++;
+				}
 
                 operationCount[operationListCount]++;
 
-                update |= (update1 | update2);
+                update |= updateChild;
 
             }
         }

--- a/src/beast/evolution/likelihood/BeerLikelihoodCore.java
+++ b/src/beast/evolution/likelihood/BeerLikelihoodCore.java
@@ -159,12 +159,11 @@ public class BeerLikelihoodCore extends LikelihoodCore {
     /**
      * Calculates partial likelihoods at a node where the children have partials.
      */
-    protected void calculatePartialsPruning(List<double[]> partials, List<double[]> pmatrices,
-                                            List<int[]> states, List<double[]> smatrices,
-                                                    double[] partials3) {
+	protected void calculatePartialsPruning(List<double[]> partials, List<double[]> pmatrices, List<int[]> states,
+			List<double[]> smatrices, double[] partials3) {
 
-        int u = 0;
-        int v = 0;
+		int u = 0;
+		int v = 0;
 
         for (int l = 0; l < nrOfMatrices; l++) {
             for (int k = 0; k < nrOfPatterns; k++) {
@@ -517,7 +516,6 @@ public class BeerLikelihoodCore extends LikelihoodCore {
      */
     @Override
 	public void createNodePartials(int nodeIndex) {
-
         this.partials[0][nodeIndex] = new double[partialsSize];
         this.partials[1][nodeIndex] = new double[partialsSize];
     }
@@ -540,11 +538,6 @@ public class BeerLikelihoodCore extends LikelihoodCore {
         } else {
             System.arraycopy(partials, 0, this.partials[0][nodeIndex], 0, partials.length);
         }
-    }
-
-    @Override
-    public void getNodePartials(int nodeIndex, double[] partialsOut) {
-        System.arraycopy(partials[currentPartialsIndex[nodeIndex]][nodeIndex], 0, partialsOut, 0, partialsOut.length);
     }
 
     /**
@@ -763,18 +756,27 @@ public class BeerLikelihoodCore extends LikelihoodCore {
         return logScalingFactor;
     }
 
+    @Deprecated
+    public void getPartials(int nodeIndex, double[] outPartials) {
+        getNodePartials(nodeIndex, outPartials);
+    }
+
     /**
      * Gets the partials for a particular node.
      *
      * @param nodeIndex   the node
      * @param outPartials an array into which the partials will go
      */
-    public void getPartials(int nodeIndex, double[] outPartials) {
-        double[] partials1 = partials[currentPartialsIndex[nodeIndex]][nodeIndex];
-
-        System.arraycopy(partials1, 0, outPartials, 0, partialsSize);
+    @Override
+    public void getNodePartials(int nodeIndex, double[] partialsOut) {
+        System.arraycopy(
+        		partials[currentPartialsIndex[nodeIndex]][nodeIndex],
+        		0,
+        		partialsOut,
+        		0,
+        		partialsOut.length);
     }
-
+    
     /**
      * Store current state
      */

--- a/src/beast/evolution/likelihood/LikelihoodCore.java
+++ b/src/beast/evolution/likelihood/LikelihoodCore.java
@@ -133,12 +133,6 @@ abstract public class LikelihoodCore {
      */
     abstract public double getLogScalingFactor(int patternIndex_);
 
-    /**
-     * Calculate partials for node node3, with children node1 and node2Index.
-     * NB Depending on whether the child nodes contain states or partials, the
-     * calculation differs-*
-     */
-    abstract public void calculatePartials(int node1, int node2Index, int node3);
     //abstract public void calculatePartials(int node1, int node2Index, int node3, int[] matrixMap);
 
     /**
@@ -181,4 +175,12 @@ abstract public class LikelihoodCore {
     abstract public void restore();
 //    /** do internal diagnosics, and suggest an alternative core if appropriate **/ 
 //    abstract LikelihoodCore feelsGood();
+
+	/**
+	 * Calculates partial likelihoods at a node.
+	 *
+	 * @param nodeIndices the array of child nodes
+	 * @param nodeIndex3  the 'parent' node
+	 */
+	abstract public void calculatePartials(int[] nodeIndices, int nodeIndex3);
 }

--- a/src/beast/evolution/likelihood/TreeLikelihood.java
+++ b/src/beast/evolution/likelihood/TreeLikelihood.java
@@ -253,8 +253,8 @@ public class TreeLikelihood extends GenericTreeLikelihood {
                 true, m_useAmbiguities.get()
         );
 
-        final int extNodeCount = nodeCount / 2 + 1;
-        final int intNodeCount = nodeCount / 2;
+        final int intNodeCount = treeInput.get().getInternalNodeCount();
+        final int extNodeCount = nodeCount - intNodeCount;
 
         if (m_useAmbiguities.get() || m_useTipLikelihoods.get()) {
             setPartials(treeInput.get().getRoot(), dataInput.get().getPatternCount());

--- a/src/beast/evolution/operators/ScaleOperator.java
+++ b/src/beast/evolution/operators/ScaleOperator.java
@@ -133,8 +133,10 @@ public class ScaleOperator extends Operator {
                     final Node root = tree.getRoot();
                     final double newHeight = root.getHeight() * scale;
 
-                    if (newHeight < Math.max(root.getLeft().getHeight(), root.getRight().getHeight())) {
-                        return Double.NEGATIVE_INFINITY;
+                    for (Node child : root.getChildren()) {
+                    	if (newHeight < child.getHeight()) {
+                    		return Double.NEGATIVE_INFINITY;
+                    	}
                     }
                     root.setHeight(newHeight);
                     return -Math.log(scale);

--- a/src/beast/evolution/operators/SubtreeSlide.java
+++ b/src/beast/evolution/operators/SubtreeSlide.java
@@ -249,8 +249,10 @@ public class SubtreeSlide extends TreeOperator {
             // TODO: verify that this makes sense
             return 0;
         } else {
-            final int count = intersectingEdges(node.getLeft(), height, directChildren) +
-                    intersectingEdges(node.getRight(), height, directChildren);
+            int count = 0;
+            for (Node child: node.getChildren()) {
+            	count += intersectingEdges(child, height, directChildren);            	
+            }
             return count;
         }
     }

--- a/src/beast/evolution/operators/TreeOperator.java
+++ b/src/beast/evolution/operators/TreeOperator.java
@@ -29,6 +29,7 @@ import beast.core.Description;
 import beast.core.Input;
 import beast.core.Input.Validate;
 import beast.core.Operator;
+import beast.evolution.tree.BinaryTreeExpectedException;
 import beast.evolution.tree.Node;
 import beast.evolution.tree.Tree;
 
@@ -45,10 +46,13 @@ abstract public class TreeOperator extends Operator {
      * @return the other child of the given parent.
      */
     protected Node getOtherChild(final Node parent, final Node child) {
-        if (parent.getLeft().getNr() == child.getNr()) {
-            return parent.getRight();
+    	if (parent.getChildCount() != 2) {
+    		throw new BinaryTreeExpectedException("Tree operator " + this.getID() + " assumes binary trees.");
+    	}
+        if (parent.getChild(0).getNr() == child.getNr()) {
+            return parent.getChild(1);
         } else {
-            return parent.getLeft();
+            return parent.getChild(0);
         }
     }
 

--- a/src/beast/evolution/operators/Uniform.java
+++ b/src/beast/evolution/operators/Uniform.java
@@ -98,7 +98,10 @@ public class Uniform extends TreeOperator {
             node = tree.getNode(nodeNr);
         } while (node.isRoot() || node.isLeaf());
         final double upper = node.getParent().getHeight();
-        final double lower = Math.max(node.getLeft().getHeight(), node.getRight().getHeight());
+        double lower = 0.0;
+        for (Node child: node.getChildren()) {
+        	lower = Math.max(child.getHeight(), lower);
+        }
         final double newValue = (Randomizer.nextDouble() * (upper - lower)) + lower;
         node.setHeight(newValue);
 

--- a/src/beast/evolution/speciation/CalibratedBirthDeathModel.java
+++ b/src/beast/evolution/speciation/CalibratedBirthDeathModel.java
@@ -986,11 +986,9 @@ public class CalibratedBirthDeathModel extends SpeciesTreeDistribution {
      * @param node   subtree root
      * @return the number of leaves under this node.
      */
+    @Deprecated
     public static int getLeafCount(final Node node) {
-        if (node.isLeaf()) {
-            return 1;
-        }
-        return getLeafCount(node.getLeft()) + getLeafCount(node.getRight());
+    	return node.getLeafNodeCount();
     }
 
     // log likelihood and clades heights

--- a/src/beast/evolution/speciation/CalibratedYuleModel.java
+++ b/src/beast/evolution/speciation/CalibratedYuleModel.java
@@ -865,11 +865,9 @@ public class CalibratedYuleModel extends SpeciesTreeDistribution {
      * @param node
      * @return the number of leaves under this node.
      */
+    @Deprecated
     public static int getLeafCount(final Node node) {
-        if (node.isLeaf()) {
-            return 1;
-        }
-        return getLeafCount(node.getLeft()) + getLeafCount(node.getRight());
+    	return node.getLeafNodeCount();
     }
 
     // log likelihood and clades heights

--- a/src/beast/evolution/tree/BinaryTreeExpectedException.java
+++ b/src/beast/evolution/tree/BinaryTreeExpectedException.java
@@ -1,0 +1,10 @@
+package beast.evolution.tree;
+
+public class BinaryTreeExpectedException extends RuntimeException {
+	public BinaryTreeExpectedException(String message) {
+		// TODO Auto-generated constructor stub
+	}
+
+	private static final long serialVersionUID = -3693129047502640523L;
+
+}

--- a/src/beast/evolution/tree/coalescent/TreeIntervals.java
+++ b/src/beast/evolution/tree/coalescent/TreeIntervals.java
@@ -385,7 +385,7 @@ public class TreeIntervals extends CalculationNode implements IntervalList {
                     //assert childCounts[indices[nodeNo]] == beast.tree.getChildCount(parent);
                     //for (int j = 0; j < lineagesRemoved + 1; j++) {
                     for (int j = 0; j < childCount; j++) {
-                        Node child = j == 0 ? parent.getLeft() : parent.getRight();
+                        Node child = parent.getChild(j);
                         removeLineage(intervalCount, child);
                     }
 
@@ -473,7 +473,7 @@ public class TreeIntervals extends CalculationNode implements IntervalList {
         for (int i = 0; i < nodes.length; i++) {
             Node node = nodes[i];
             times[i] = node.getHeight();
-            childCounts[i] = node.isLeaf() ? 0 : 2;
+            childCounts[i] = node.getChildCount();
         }
     }
 

--- a/test/beast/evolution/likelihood/TestNonBifurcatingLikelihood.java
+++ b/test/beast/evolution/likelihood/TestNonBifurcatingLikelihood.java
@@ -1,0 +1,184 @@
+package beast.evolution.likelihood;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import beast.evolution.alignment.Alignment;
+import beast.evolution.alignment.Sequence;
+import beast.evolution.likelihood.BeerLikelihoodCore;
+import beast.evolution.likelihood.TreeLikelihood;
+import beast.evolution.sitemodel.SiteModel;
+import beast.evolution.substitutionmodel.Frequencies;
+import beast.evolution.substitutionmodel.GeneralSubstitutionModel;
+import beast.util.Randomizer;
+import beast.util.TreeParser;
+import junit.framework.TestCase;
+import test.beast.BEASTTestCase;
+
+public class TestNonBifurcatingLikelihood extends TestCase {
+	@Test
+	public void testUnaryTreeLikelihood() throws Exception {
+		// Set up simple asymmetric binary model
+		Sequence tip = new Sequence("tip", "011");
+
+		Alignment data = new Alignment();
+		data.initByName("sequence", tip, "dataType", "binary", "statecount", "2");
+
+		assertEquals(1, data.getPatternWeight(0));
+		assertEquals(2, data.getPatternWeight(1));
+
+		TreeParser tree = new TreeParser();
+		tree.initByName("taxa", data, "newick", "((tip:1):1):1;", "IsLabelledNewick", true);
+
+		Frequencies freq = new Frequencies();
+		freq.initByName("frequencies", "0.5 0.5");
+
+		GeneralSubstitutionModel lossModel = new GeneralSubstitutionModel();
+		lossModel.initByName("rates", "1e-23 1.0", "frequencies", freq);
+
+		SiteModel siteModel = new SiteModel();
+		siteModel.initByName("mutationRate", "1.0", "substModel", lossModel);
+
+		System.setProperty("java.only", "true");
+		TreeLikelihood likelihood = new TreeLikelihood();
+
+		likelihood.initByName("data", data, "tree", tree, "siteModel", siteModel);
+		double logP = likelihood.calculateLogP();
+
+		// Check the likelihood calculation
+		double[][] rateMatrix = lossModel.getRateMatrix();
+		assertEquals(2, rateMatrix.length);
+		// The diagonal entries are 1s...
+		assertArrayEquals(new double[] { 1.0, 1.0 }, rateMatrix[0], BEASTTestCase.PRECISION);
+		assertArrayEquals(new double[] { 0.0, 1.0 }, rateMatrix[1], BEASTTestCase.PRECISION);
+		/*
+		 * ... but will be normalized to minus rowsum, so -2 2 0 0 (the 2 is there give
+		 * an average of 1 transition per unit time, based on the fixed frequencies of
+		 * 0.5), which has eigenvalues 0 and -2
+		 */
+		assertArrayEquals(new double[] { 0.0, -2.0 }, lossModel.getEigenDecomposition(null).getEigenValues(),
+				BEASTTestCase.PRECISION);
+		/*
+		 * with eigen vectorspaces spanned by eigenvectors [1, 1] (for eigenvalue 0) and
+		 * [0, 1] (for eigenvalue -2).
+		 */
+		assertArrayEquals(new double[] { Math.sqrt(0.5), 0.0, Math.sqrt(0.5), Math.sqrt(2) },
+				lossModel.getEigenDecomposition(null).getEigenVectors(), BEASTTestCase.PRECISION);
+
+		/*
+		 * The transition probabilities along an edge of length 1 are then
+		 * 
+		 * exp([[-2, 2], [0, 0]]) = [[1, 0], [1, 1]] * exp(diag[0, -2]) * [[1, 0], [1,
+		 * 1]] ^ -1 = [[1, 0], [1, 1]] * diag[1, exp(-2)] * [[1, 0], [1, 1]] ^ -1 = [[1,
+		 * 0], [1-1/e^2, 1/e^2]]
+		 */
+		double[] partials = new double[4];
+		likelihood.getLikelihoodCore().getNodePartials(1, partials);
+		/*
+		 * For the first pattern (0), the likelihood of obtaining it when starting in
+		 * state 0 is 1, because our 1→0 transition probability is negligible. The
+		 * probability to obtain it when starting in state 1 is 1-p_{1→0}. Getting the
+		 * second pattern (1) starting from 0 is impossible (likelihood 0), and the last
+		 * entry is the transition probability p_{1→0}.
+		 */
+		assertArrayEquals(new double[] { 1.0, 1 - Math.exp(-2), 0.0, Math.exp(-2) }, partials, BEASTTestCase.PRECISION);
+
+		/*
+		 * Now node2, the root, sits on top of another length 1 branch above node1, and
+		 * therefore should have the square of that previous case, and a square of the partials.
+		 */
+		likelihood.getLikelihoodCore().getNodePartials(2, partials);
+		assertArrayEquals(new double[] { 1.0, 1 - Math.exp(-4), 0.0, Math.exp(-4) }, partials, BEASTTestCase.PRECISION);
+	}
+
+	@Test
+	public void testLikelihoodBinaryAndGenericSS() throws Exception {
+		int nrOfStates = 3;
+		BeerLikelihoodCore core = new BeerLikelihoodCore(nrOfStates);
+		core.initialize(1, 1, 1, false, true);
+
+		int[] states1 = new int[] { 0 };
+		double[] matrices1 = new double[] { 0.9, 0.0, 0.1, 0.5, 0.5, 0.0, 0.0, 0.0, 1.0 };
+		int[] states2 = new int[] { 0 };
+		double[] matrices2 = new double[] { 0.9, 0.0, 0.1, 0.5, 0.5, 0.0, 0.0, 0.0, 1.0 };
+		double[] partials3 = new double[] { 0.0, 0.0, 0.0 };
+		core.calculateStatesStatesPruning(states1, matrices1, states2, matrices2, partials3);
+		double[] partials3new = new double[] { 0.0, 0.0, 0.0 };
+		core.calculatePartialsPruning((List<double[]>) new ArrayList<double[]>(0),
+				(List<double[]>) new ArrayList<double[]>(0), Arrays.asList(new int[][] { states1, states2 }),
+				Arrays.asList(new double[][] { matrices1, matrices2 }), partials3new);
+		assertArrayEquals(partials3, partials3new, BEASTTestCase.PRECISION);
+		assertArrayEquals(new double[] { 0.81, 0.25, 0.0 }, partials3new, BEASTTestCase.PRECISION);
+	}
+
+	@Test
+	public void testLikelihoodBinaryAndGenericSS2Patterns() throws Exception {
+		int nrOfStates = 3;
+		BeerLikelihoodCore core = new BeerLikelihoodCore(nrOfStates);
+		core.initialize(1, 2, 1, false, true);
+
+		int[] states1 = new int[] { 0, 1 };
+		double[] matrices1 = new double[] { 0.9, 0.0, 0.1, 0.5, 0.5, 0.0, 0.0, 0.0, 1.0 };
+		int[] states2 = new int[] { 0, 0 };
+		double[] matrices2 = new double[] { 0.9, 0.0, 0.1, 0.5, 0.5, 0.0, 0.0, 0.0, 1.0 };
+		double[] partials3 = new double[] { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+		core.calculateStatesStatesPruning(states1, matrices1, states2, matrices2, partials3);
+		double[] partials3new = new double[] { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+		core.calculatePartialsPruning((List<double[]>) new ArrayList<double[]>(0),
+				(List<double[]>) new ArrayList<double[]>(0), Arrays.asList(new int[][] { states1, states2 }),
+				Arrays.asList(new double[][] { matrices1, matrices2 }), partials3new);
+		assertArrayEquals(partials3, partials3new, BEASTTestCase.PRECISION);
+		assertArrayEquals(new double[] { 0.81, 0.25, 0.0, 0.0, 0.25, 0.0 }, partials3new, BEASTTestCase.PRECISION);
+	}
+
+	@Test
+	public void testLikelihoodBinaryAndGenericPS() throws Exception {
+		int nrOfStates = 3;
+		BeerLikelihoodCore core = new BeerLikelihoodCore(nrOfStates);
+		core.initialize(1, 1, 1, false, true);
+		double r1 = Randomizer.nextDouble();
+		double r2 = Randomizer.nextDouble();
+
+		double[] partials1 = new double[] { r1, r2 * (1 - r1), (1 - r2) * (1 - r1) };
+		double[] matrices1 = new double[] { 0.9, 0.0, 0.1, 0.5, 0.5, 0.0, 0.0, 0.0, 1.0 };
+		int[] states2 = new int[] { 0 };
+		double[] matrices2 = new double[] { 0.9, 0.0, 0.1, 0.5, 0.5, 0.0, 0.0, 0.0, 1.0 };
+		double[] partials3 = new double[] { 0.0, 0.0, 0.0 };
+		core.calculateStatesPartialsPruning(states2, matrices2, partials1, matrices1, partials3);
+		double[] partials3new = new double[] { 0.0, 0.0, 0.0 };
+		core.calculatePartialsPruning(Arrays.asList(new double[][] { partials1 }),
+				Arrays.asList(new double[][] { matrices1 }), Arrays.asList(new int[][] { states2 }),
+				Arrays.asList(new double[][] { matrices2 }), partials3new);
+		assertArrayEquals(partials3, partials3new, BEASTTestCase.PRECISION);
+		assertEquals((r1 * 0.9 + (1 - r2) * (1 - r1) * 0.1) * 0.9, partials3[0]);
+	}
+
+	@Test
+	public void testLikelihoodBinaryAndGenericPP() throws Exception {
+		int nrOfStates = 3;
+		BeerLikelihoodCore core = new BeerLikelihoodCore(nrOfStates);
+		core.initialize(1, 1, 1, false, true);
+		double r1 = Randomizer.nextDouble();
+		double r2 = Randomizer.nextDouble();
+		double r3 = Randomizer.nextDouble();
+		double r4 = Randomizer.nextDouble();
+
+		double[] partials1 = new double[] { r1, r2 * (1 - r1), (1 - r2) * (1 - r1) };
+		double[] matrices1 = new double[] { 0.9, 0.0, 0.1, 0.5, 0.5, 0.0, 0.0, 0.0, 1.0 };
+		double[] partials2 = new double[] { r3, r4 * (1 - r3), (1 - r4) * (1 - r3) };
+		double[] matrices2 = new double[] { 0.9, 0.0, 0.1, 0.5, 0.5, 0.0, 0.0, 0.0, 1.0 };
+		double[] partials3 = new double[] { 0.0, 0.0, 0.0 };
+		core.calculatePartialsPartialsPruning(partials1, matrices1, partials2, matrices2, partials3);
+		double[] partials3new = new double[] { 0.0, 0.0, 0.0 };
+		core.calculatePartialsPruning(Arrays.asList(new double[][] { partials1, partials2 }),
+				Arrays.asList(new double[][] { matrices1, matrices2 }), (List<int[]>) new ArrayList<int[]>(0),
+				(List<double[]>) new ArrayList<double[]>(0), partials3new);
+		assertArrayEquals(partials3, partials3new, BEASTTestCase.PRECISION);
+		assertEquals((r1 * 0.9 + (1 - r2) * (1 - r1) * 0.1) * (r3 * 0.9 + (1 - r4) * (1 - r3) * 0.1), partials3[0]);
+	}
+}


### PR DESCRIPTION
I spent some spare time today trying to make BEAST2 more capable of dealing with non-binary trees. Getting the maths for topology-changing operators right will be trivial, but supporting as a first step multifurcations and degree-two-nodes (maybe at some point making sampled ancestors a bit simpler) on branches looked very doable.

I probably introduced some bug somewhere, so I'd be happy to get a code review and pointers to test cases I could write.

 - Introduce new BinaryTreeExpectedException
 - Make set/getLeft/Right throw exceptions if called in a non-binary-tree
   context, because it's probably from somewhere which doesn't support
 - non-binary trees
 - Make several core beast2 classes not depend on getLeft etc.
 - Make test for binary trees explicit in other classes