### PR TITLE
Make NexusParser more robust and allow Fasta imports to select from all data types

### DIFF
--- a/src/beast/app/beauti/BeautiAlignmentProvider.java
+++ b/src/beast/app/beauti/BeautiAlignmentProvider.java
@@ -9,14 +9,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.StringReader;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import javax.swing.JComboBox;
 import javax.swing.JOptionPane;
@@ -558,16 +551,50 @@ public class BeautiAlignmentProvider extends BEASTObject {
 			        if (mayBeAminoacid) {
 			        	switch (this.datatype) {
 				        	case userdefined:
-				        		// make user choose 
-					        	JComboBox<String> jcb = new JComboBox<>(new String[]{"aminoacid", "nucleotide", "all are aminoacid", "all are nucleotide"});
-					        	jcb.setEditable(true);
+				        		// make user choose
+								TreeMap<String, DataType> allTypes = Alignment.getTypes();
+								String[] dataNames = new String[allTypes.keySet().size() + 2];
+								dataNames[0] = "aminoacid";
+								dataNames[1] = "nucleotide";
+								dataNames[2] = "all are aminoacid";
+								dataNames[3] = "all are nucleotide";
+								int i = 4;
+								for (String key: allTypes.keySet()) {
+									if (!key.equals("nucleotide") && !key.equals("aminoacid")) {
+										dataNames[i] = key;
+										i++;
+									}
+								}
+								JComboBox<String> jcb = new JComboBox<>(dataNames);
+								jcb.setEditable(true);
 					        	jcb.setSelectedItem(datatype);
 					        	JOptionPane.showMessageDialog(null, jcb, "Choose the datatype of alignment " + alignment.getID(), JOptionPane.QUESTION_MESSAGE);
-					        	switch ((String) jcb.getSelectedItem()) {
-						        	case "aminoacid": datatype = "aminoacid"; totalCount = 20; break;
-						        	case "nucleotide": datatype = "nucleotide"; totalCount = 4; break;
-						        	case "all are aminoacid": datatype = "aminoacid"; this.datatype = dtype.aminoacid; totalCount = 20; break;
-						        	case "all are nucleotide": datatype = "nucleotide"; this.datatype = dtype.nucleotide; totalCount = 4; break;
+					        	// match selected data type
+					        	String selectedType = (String) jcb.getSelectedItem();
+					        	switch (selectedType) {
+						        	case "aminoacid":
+						        		datatype = "aminoacid";
+						        		totalCount = 20;
+						        		break;
+						        	case "nucleotide":
+						        		datatype = "nucleotide";
+						        		totalCount = 4;
+						        		break;
+						        	case "all are aminoacid":
+						        		datatype = "aminoacid";
+						        		this.datatype = dtype.aminoacid;
+						        		totalCount = 20;
+						        		break;
+						        	case "all are nucleotide":
+						        		datatype = "nucleotide";
+						        		this.datatype = dtype.nucleotide;
+						        		totalCount = 4;
+						        		break;
+									default:
+										// catch all for other data types
+										datatype = selectedType;
+										totalCount = allTypes.get(selectedType).getStateCount();
+										break;
 					        	}
 					        	break;
 				        	case aminoacid:

--- a/src/beast/evolution/alignment/Alignment.java
+++ b/src/beast/evolution/alignment/Alignment.java
@@ -86,6 +86,10 @@ public class Alignment extends Map<String> {
         return types.get(name);
     }
 
+    static public TreeMap<String, DataType> getTypes() {
+        return types;
+    }
+
     final public Input<List<Sequence>> sequenceInput =
             new Input<>("sequence", "sequence and meta data for particular taxon", new ArrayList<>(), Validate.OPTIONAL);
 

--- a/src/beast/util/NexusParser.java
+++ b/src/beast/util/NexusParser.java
@@ -760,7 +760,9 @@ public class NexusParser {
                     // generic data type look up if nothing else works
                     DataType dataType = Alignment.getDataTypeByName(dataTypeName);
                     if (dataType != null) {
-                        alignment.dataTypeInput.setValue(dataTypeName, alignment);
+                        // robustly set data type for names with upper and lower case
+                        String dataTypeNameRobust = Alignment.getDataTypeByName(dataTypeName).getTypeDescription();
+                        alignment.dataTypeInput.setValue(dataTypeNameRobust, alignment);
                         totalCount = dataType.getStateCount();
                     }  else {
                         // set to integer as last resort


### PR DESCRIPTION
This pull request includes changes to the Nexus and Fasta importers to improve data type compatibility.

1. NexusParser's default behaviour sets all datatypes in the xml to lower case. This causes a problem for datatypes that have both upper and lower case in their description. I have adjusted the code to get the description from the DataType class rather than use the lower case string.

2. The current Fasta importer allows data types to be selected from `aminoacid, nucleotide, all aminoacid, all nucleotide`. I have extended this to allow all other data types to be selected when the type cannot be determined.