### PR TITLE
change access to calcPatterns and SiteComparator

### DIFF
--- a/src/beast/evolution/alignment/Alignment.java
+++ b/src/beast/evolution/alignment/Alignment.java
@@ -562,7 +562,7 @@ public class Alignment extends Map<String> {
      * SiteComparator is used for ordering the sites,
      * which makes it easy to identify patterns.
      */
-    class SiteComparator implements Comparator<int[]> {
+    public class SiteComparator implements Comparator<int[]> {
         @Override
 		public int compare(int[] o1, int[] o2) {
             for (int i = 0; i < o1.length; i++) {
@@ -582,11 +582,11 @@ public class Alignment extends Map<String> {
         calcPatterns(true);
     }
 
-        /**
-         * calculate patterns from sequence data
-         * *
-         */
-    private void calcPatterns(boolean log) {
+    /**
+     * calculate patterns from sequence data
+     * *
+     */
+    protected void calcPatterns(boolean log) {
         int taxonCount = counts.size();
         int siteCount = counts.get(0).size();
 


### PR DESCRIPTION
Hi!

I need to override `Alignment.java` for my Beast2 package, for this I need to be able to override `calcPatterns(boolean log)`. I can see that `calcPatterns()` already is not private, so I think `calcPatterns(boolean log)` can be protected too. Also I change an access for `SiteComparator`, now it can be used in different packages. 