### PR TITLE
Allows scientific notation for input parameters

### DIFF
--- a/src/beast/core/Input.java
+++ b/src/beast/core/Input.java
@@ -33,7 +33,7 @@ import java.lang.reflect.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
+import java.math.BigDecimal;
 
 /**
  * Represents input of a BEASTObject class.
@@ -600,7 +600,7 @@ public class Input<T> {
             String[] stringValues = stringValue2.split("\\s+");
             for (int i = 0; i < stringValues.length; i++) {
                 if (theClass.equals(Integer.class)) {
-                    list.add(new Integer(stringValues[i % stringValues.length]));
+                    list.add(new BigDecimal(stringValues[i % stringValues.length]).intValueExact());
                 } else if (theClass.equals(Double.class)) {
                     list.add(new Double(stringValues[i % stringValues.length]));
                 } else if (theClass.equals(Boolean.class)) {
@@ -614,11 +614,11 @@ public class Input<T> {
         }
 
         if (theClass.equals(Integer.class)) {
-            value = (T) new Integer(stringValue);
+            value = (T) (Integer) new BigDecimal(stringValue).intValueExact();
             return;
         }
         if (theClass.equals(Long.class)) {
-            value = (T) new Long(stringValue);
+            value = (T) (Long) new BigDecimal(stringValue).longValueExact();
             return;
         }
         if (theClass.equals(Double.class)) {

--- a/src/test/beast/core/InputTest.java
+++ b/src/test/beast/core/InputTest.java
@@ -1,18 +1,24 @@
 package test.beast.core;
 
+import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
 
 import beast.core.*;
 import beast.core.Input.Validate;
-import junit.framework.TestCase;
+import org.junit.rules.ExpectedException;
 
-public class InputTest extends TestCase {
+public class InputTest {
 
 	@Description("class that impements BEASTInterface but is not a BEASTObject")
 	@Citation("this is a dummy citation")
 	public class BEASTi extends BEASTObject {
 		final public Input<String> msgInput = new Input<>("value", "message for this BEASTi object", Validate.OPTIONAL);
 		final public Input<String> msg2Input = new Input<>("value2", "message2 for this BEASTi object", Validate.OPTIONAL);
+		final public Input<Integer> intValue = new Input<>("intValue", "Integer message for this BEASTi object", Validate.OPTIONAL);
+		final public Input<Long> longValue = new Input<>("longValue", "Long message for this BEASTi object", Validate.OPTIONAL);
+		final public Input<Double> doubleValue = new Input<>("doubleValue", "Double message2 for this BEASTi object", Validate.OPTIONAL);
+
 
 		@Override
 		public void initAndValidate() {
@@ -29,7 +35,39 @@ public class InputTest extends TestCase {
 		// following should pass without error message
 		BEASTi o = new BEASTi();
 		o.initByName("value","ok");
-
 	}
-	
+
+
+	@Test
+	public void testScienticNotation() {
+		BEASTi o = new BEASTi();
+		o.initByName("intValue", "5e5");
+		o.initByName("longValue", "5e5");
+		o.initByName("doubleValue", "5e5");
+
+		Assert.assertEquals(500000, (int) o.intValue.get());
+		Assert.assertEquals(500000, (long) o.longValue.get());
+		Assert.assertEquals(500000.0, (double) o.doubleValue.get(), 1);
+	}
+
+	@Rule
+	public final ExpectedException exception = ExpectedException.none();
+	@Test
+	public void testScientificNotationDecimalFailure() {
+
+		exception.expect(java.lang.RuntimeException.class);
+		exception.expectMessage("Failed to set the string value to '1e-1' for beastobject id=null");
+
+		BEASTi o = new BEASTi();
+		o.initByName("intValue", "1e-1");
+	}
+
+	@Test
+	public void testScientificNotationIntTooLarge() {
+		exception.expect(java.lang.RuntimeException.class);
+		exception.expectMessage("Failed to set the string value to '" + Integer.MAX_VALUE + "0' for beastobject id=null");
+
+		BEASTi o = new BEASTi();
+		o.initByName("intValue", Integer.MAX_VALUE + "0" );
+	}
 }


### PR DESCRIPTION
This should resolve the issue https://github.com/CompEvol/beast2/issues/1024.

By converting first to `BigDecimal`, and then to `Long` and `Integer`, we can handle scientific notation. The advantage of `BigDecimal.intValueExact()` is that it throws the correct errors, if the scientific notation is too large or if the scientific notation encodes a decimal number.

Added some tests as well. Junit 4 is a bit lacking regarding expected exceptions, so I tested only behaviour around `Integer` and not all parameters.

`Double` and `Float` should already handle scientific notation just fine.