### PR TITLE
Replace RealParameter inputs with Functions in population models.

### DIFF
--- a/src/beast/evolution/tree/coalescent/ConstantPopulation.java
+++ b/src/beast/evolution/tree/coalescent/ConstantPopulation.java
@@ -1,13 +1,14 @@
 package beast.evolution.tree.coalescent;
 
 
-import java.util.Collections;
-import java.util.List;
-
+import beast.core.BEASTObject;
 import beast.core.Description;
+import beast.core.Function;
 import beast.core.Input;
 import beast.core.Input.Validate;
-import beast.core.parameter.RealParameter;
+
+import java.util.ArrayList;
+import java.util.List;
 /*
  * ConstantPopulation.java
  *
@@ -41,7 +42,7 @@ import beast.core.parameter.RealParameter;
  */
 @Description("coalescent intervals for a constant population")
 public class ConstantPopulation extends PopulationFunction.Abstract {
-    final public Input<RealParameter> popSizeParameter = new Input<>("popSize",
+    final public Input<Function> popSizeParameter = new Input<>("popSize",
             "constant (effective) population size value.", Validate.REQUIRED);
 
     //
@@ -52,7 +53,7 @@ public class ConstantPopulation extends PopulationFunction.Abstract {
      * @return initial population size.
      */
     public double getN0() {
-        N0 = popSizeParameter.get().getValue();
+        N0 = popSizeParameter.get().getArrayValue();
         return N0;
     }
 
@@ -70,7 +71,11 @@ public class ConstantPopulation extends PopulationFunction.Abstract {
 
     @Override
 	public List<String> getParameterIds() {
-        return Collections.singletonList(popSizeParameter.get().getID());
+        List<String> ids = new ArrayList<>();
+        if (popSizeParameter.get() instanceof BEASTObject)
+            ids.add(((BEASTObject)popSizeParameter.get()).getID());
+
+        return ids;
     }
 
     @Override

--- a/src/beast/evolution/tree/coalescent/ExponentialGrowth.java
+++ b/src/beast/evolution/tree/coalescent/ExponentialGrowth.java
@@ -1,12 +1,14 @@
 package beast.evolution.tree.coalescent;
 
 
-import java.util.Collections;
-import java.util.List;
-
+import beast.core.BEASTObject;
 import beast.core.Description;
+import beast.core.Function;
 import beast.core.Input;
 import beast.core.parameter.RealParameter;
+
+import java.util.ArrayList;
+import java.util.List;
 /*
  * ConstantPopulation.java
  *
@@ -40,9 +42,9 @@ import beast.core.parameter.RealParameter;
  */
 @Description("Coalescent intervals for a exponentially growing population.")
 public class ExponentialGrowth extends PopulationFunction.Abstract {
-    final public Input<RealParameter> popSizeParameterInput = new Input<>("popSize",
+    final public Input<Function> popSizeParameterInput = new Input<>("popSize",
             "present-day population size (defaults to 1.0). ");
-    final public Input<RealParameter> growthRateParameterInput = new Input<>("growthRate",
+    final public Input<Function> growthRateParameterInput = new Input<>("growthRate",
             "Growth rate is the exponent of the exponential growth. " +
             "A value of zero represents a constant population size, negative values represent " +
             "decline towards the present, positive numbers represents exponential growth towards " +
@@ -54,21 +56,17 @@ public class ExponentialGrowth extends PopulationFunction.Abstract {
 
     @Override
 	public void initAndValidate() {
-        if (popSizeParameterInput.get() != null) {
-            popSizeParameterInput.get().setBounds(
-            		Math.max(0.0, popSizeParameterInput.get().getLower()), 
-            		popSizeParameterInput.get().getUpper());
+        if (popSizeParameterInput.get() != null && popSizeParameterInput.get() instanceof RealParameter) {
+            RealParameter param = (RealParameter) popSizeParameterInput.get();
+            param.setBounds( Math.max(0.0, param.getLower()), param.getUpper());
         }
-//        if (growthRateParameter.get() != null) {
-//            growthRateParameter.get().setBounds(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
-//        }
     }
 
     /**
      * @return initial population size.
      */
     public double getN0() {
-        return popSizeParameterInput.get().getValue();
+        return popSizeParameterInput.get().getArrayValue();
     }
 
     /**
@@ -84,7 +82,7 @@ public class ExponentialGrowth extends PopulationFunction.Abstract {
      * @return growth rate.
      */
     public final double getGrowthRate() {
-        return growthRateParameterInput.get().getValue();
+        return growthRateParameterInput.get().getArrayValue();
     }
 
     /**
@@ -157,7 +155,11 @@ public class ExponentialGrowth extends PopulationFunction.Abstract {
 
     @Override
 	public List<String> getParameterIds() {
-        return Collections.singletonList(popSizeParameterInput.get().getID());
+        List<String> ids = new ArrayList<>();
+        if (popSizeParameterInput.get() instanceof BEASTObject)
+            ids.add(((BEASTObject)popSizeParameterInput.get()).getID());
+
+        return ids;
     }
 
 //    public int getNumArguments() {

--- a/src/beast/evolution/tree/coalescent/ScaledPopulationFunction.java
+++ b/src/beast/evolution/tree/coalescent/ScaledPopulationFunction.java
@@ -1,13 +1,10 @@
 package beast.evolution.tree.coalescent;
 
 
-import java.util.List;
-
-import beast.core.CalculationNode;
-import beast.core.Description;
-import beast.core.Input;
+import beast.core.*;
 import beast.core.Input.Validate;
-import beast.core.parameter.RealParameter;
+
+import java.util.List;
 
 
 /**
@@ -20,7 +17,7 @@ public class ScaledPopulationFunction extends PopulationFunction.Abstract {
     final public Input<PopulationFunction> popParameterInput = new Input<>("population",
             "population function to scale. ", Validate.REQUIRED);
 
-    final public Input<RealParameter> scaleFactorInput = new Input<>("factor",
+    final public Input<Function> scaleFactorInput = new Input<>("factor",
             "scale population by this facor.", Validate.REQUIRED);
 
     public ScaledPopulationFunction() {
@@ -31,19 +28,21 @@ public class ScaledPopulationFunction extends PopulationFunction.Abstract {
     @Override
 	public List<String> getParameterIds() {
         List<String> ids = popParameterInput.get().getParameterIds();
-        ids.add(scaleFactorInput.get().getID());
+        if (scaleFactorInput.get() instanceof BEASTObject)
+            ids.add(((BEASTObject)scaleFactorInput.get()).getID());
+
         return ids;
     }
 
     @Override
 	public double getPopSize(double t) {
-        return popParameterInput.get().getPopSize(t) * scaleFactorInput.get().getValue();
+        return popParameterInput.get().getPopSize(t) * scaleFactorInput.get().getArrayValue();
     }
 
     @Override
 	public double getIntensity(double t) {
         double intensity = popParameterInput.get().getIntensity(t);
-        double scale = scaleFactorInput.get().getValue();
+        double scale = scaleFactorInput.get().getArrayValue();
         return intensity / scale;
     }
 
@@ -54,6 +53,7 @@ public class ScaledPopulationFunction extends PopulationFunction.Abstract {
 
     @Override
     protected boolean requiresRecalculation() {
-        return ((CalculationNode) popParameterInput.get()).isDirtyCalculation() || scaleFactorInput.get().somethingIsDirty();
+        return ((CalculationNode) popParameterInput.get()).isDirtyCalculation()
+                || ((CalculationNode)scaleFactorInput.get()).isDirtyCalculation();
     }
 }


### PR DESCRIPTION
This commit replaces `RealParameter` inputs with `Function` inputs in `ExponentialGrowth`, `ConstantPopulation` and `ScaledPopulationFunction`.  This allows users to apply reparameterisations at runtime, using classes such as `Slice` and co.

I've tried to be careful, making sure that the small amount of existing code which specifically applies to either `RealParameter`s or `BEASTObject`s is retained.