### PR TITLE
Avoid misuse of BufferedReader::ready() by NexusParser.

### DIFF
--- a/src/beast/util/NexusParser.java
+++ b/src/beast/util/NexusParser.java
@@ -86,7 +86,7 @@ public class NexusParser {
             fin = new BufferedReader(reader);
         }
         try {
-            while (fin.ready()) {
+            while (true) {
                 final String str = nextLine(fin);
                 if (str == null) {
                     processSets();
@@ -108,8 +108,6 @@ public class NexusParser {
                     parseTreesBlock(fin);
                 }
             }
-            processSets();
-
         } catch (TreeParser.TreeParsingException e) {
         	e.printStackTrace();
             int errorLine = lineNr + 1;
@@ -1328,11 +1326,11 @@ public class NexusParser {
      * read line from nexus file *
      */
     protected String readLine(final BufferedReader fin) throws IOException {
-        if (!fin.ready()) {
-            return null;
-        }
-        lineNr++;
-        return fin.readLine();
+        String line = fin.readLine();
+        if (line != null)
+            lineNr++;
+
+        return line;
     }
 
     /**


### PR DESCRIPTION
NexusParser currently uses `BufferedReader::ready()` to detect the EOF, but this method actually only checks whether a call to read() will temporarily block. This patch instead uses the result of `BufferedReader::readLine()` to detect the EOF.

This change is not so important for reading local files, but it can be important if files are located on NFS mounts or the reader represents a network stream.