### PR TITLE
Remove default methods for Loggable::log()

### DIFF
--- a/src/beast/base/core/Loggable.java
+++ b/src/beast/base/core/Loggable.java
@@ -27,24 +27,7 @@ public interface Loggable {
      * @param sample chain sample number
      * @param out     log stream
      */
-    default void log(long sample, PrintStream out) {
-    	if (sample < Integer.MAX_VALUE) {
-    		log((int) sample, out);
-    	} else {
-    		throw new IllegalArgumentException("Loggable::log(long,Prinstream) was not implemented: cannot log samples larger than " + Integer.MAX_VALUE);
-    	}
-    }
-    
-    /** For backward compatibility only: the int-version of log().
-     * 
-     * Please use log(long sample, PrintStream out) instead of log(int, PrintStream)
-     */
-    @Deprecated 
-    default void log(int sample, PrintStream out) {
-    	// if either int or long version is not implemented
-    	// this ensure one of them get called
-		log((long) sample, out);    	
-    }
+    void log(long sample, PrintStream out);
     
     /**
      * close log. An end of log message can be left (as in End; for Nexus trees)


### PR DESCRIPTION
I wonder whether 2.7 might be a suitable point to finally dispense with the default implementations of the `log(int samplenr, out)` and the `log(long samplenr, out)` methods.  These implementations were in place to preserve backwards compatibility with older code.  These changes are actually very minor, esp compared to the other changes necessitated by 2.7.

The presence of these default implementations causes some confusion for both the compiler and IDEs, since the need to implement log() in a Loggable is not immediately deducible.