### PR TITLE
Don't echo commands in Windows batch files

### DIFF
--- a/release/Windows/bat/applauncher.bat
+++ b/release/Windows/bat/applauncher.bat
@@ -1,3 +1,5 @@
+@echo off
+
 REM Check whether the JRE is included
 IF EXIST %~dp0\..\jre (
 

--- a/release/Windows/bat/beast.bat
+++ b/release/Windows/bat/beast.bat
@@ -1,3 +1,5 @@
+@echo off
+
 REM Check whether the JRE is included
 IF EXIST %~dp0\..\jre (
 

--- a/release/Windows/bat/beauti.bat
+++ b/release/Windows/bat/beauti.bat
@@ -1,3 +1,5 @@
+@echo off
+
 REM Check whether the JRE is included
 IF EXIST %~dp0\..\jre (
 

--- a/release/Windows/bat/loganalyser.bat
+++ b/release/Windows/bat/loganalyser.bat
@@ -1,3 +1,5 @@
+@echo off
+
 REM Check whether the JRE is included
 IF EXIST %~dp0\..\jre (
 

--- a/release/Windows/bat/logcombiner.bat
+++ b/release/Windows/bat/logcombiner.bat
@@ -1,3 +1,5 @@
+@echo off
+
 REM Check whether the JRE is included
 IF EXIST %~dp0\..\jre (
 

--- a/release/Windows/bat/packagehealthchecker.bat
+++ b/release/Windows/bat/packagehealthchecker.bat
@@ -1,1 +1,3 @@
+@echo off
+
 %~dp0\..\jre\bin\java -cp %~dp0\..\lib\launcher.jar beast.pkgmgmt.launcher.AppLauncherLauncher PackageHealthChecker %*

--- a/release/Windows/bat/packagemanager.bat
+++ b/release/Windows/bat/packagemanager.bat
@@ -1,3 +1,5 @@
+@echo off
+
 REM Check whether the JRE is included
 IF EXIST %~dp0\..\jre (
 

--- a/release/Windows/bat/treeannotator.bat
+++ b/release/Windows/bat/treeannotator.bat
@@ -1,3 +1,5 @@
+@echo off
+
 REM Check whether the JRE is included
 IF EXIST %~dp0\..\jre (
 


### PR DESCRIPTION
The Windows batch files currently echo their commands, which is distracting. For example:
```
Microsoft Windows [Version 10.0.19044.1889]
(c) Microsoft Corporation. All rights reserved.

C:\temp\coding\BEAST\bat>beast

C:\temp\coding\BEAST\bat>REM Check whether the JRE is included

C:\temp\coding\BEAST\bat>IF EXIST C:\temp\coding\BEAST\bat\\..\jre (
REM for BEAST version that includes JRE
 C:\temp\coding\BEAST\bat\\..\jre\bin\java -cp C:\temp\coding\BEAST\bat\\..\lib\launcher.jar beast.pkgmgmt.launcher.BeastLauncher
)  ELSE (
REM for version that does not include JRE
 java -cp C:\temp\coding\BEAST\bat\\..\lib\launcher.jar beast.pkgmgmt.launcher.BeastLauncher
)

                        BEAST v2.7.0, 2002-2022
             Bayesian Evolutionary Analysis Sampling Trees
                       Designed and developed by
 Remco Bouckaert, Alexei J. Drummond, Andrew Rambaut & Marc A. Suchard
...
```

Batch files (`.bat` or `.cmd`) therefore typically begin with an `@echo off` command ["to prevent all commands in a batch file (including the echo off command) from displaying on the screen"](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/echo).
