### PR TITLE
Extend XML variable substitution to text nodes.

### DIFF
--- a/src/beast/base/parser/XMLParserUtils.java
+++ b/src/beast/base/parser/XMLParserUtils.java
@@ -175,6 +175,7 @@ public class XMLParserUtils {
 	            break;
 
 	        case Node.CDATA_SECTION_NODE:
+			case Node.TEXT_NODE:
 	        	String content = node.getTextContent();
 	        	node.setNodeValue(replaceVariablesInString(content, variableDefs));
 				break;


### PR DESCRIPTION
Currently the following use of `<plate/>` doesn't work as you might expect:

```xml
<plate var="i" range="1:10">
    <reaction spec="Reaction" rate="1">
        X[$(i)] -> 2X[$(i)]
    </reaction>
</plate>
```

This is because `XMLParserUtils::replaceVariables()` only performs substitution on attributes and the value of CDATA nodes.  This patch adds one line to extend the substitution also to the value of text nodes.

I'm submitting this as a PR since although I'm pretty sure this won't break anything, I don't know enough to say for sure!