### PR TITLE
Avoid unnecessary call to Randomizer.nextDouble()

### DIFF
--- a/src/beast/base/inference/MCMC.java
+++ b/src/beast/base/inference/MCMC.java
@@ -568,7 +568,7 @@ public class MCMC extends Runnable {
             logAlpha = newLogLikelihood - oldLogLikelihood + logHastingsRatio; //CHECK HASTINGS
             if (printDebugInfo) System.err.print(logAlpha + " " + newLogLikelihood + " " + oldLogLikelihood);
 
-            if (logAlpha >= 0 || Randomizer.nextDouble() < Math.exp(logAlpha)) {
+            if (logAlpha >= 0 || (logAlpha != Double.NEGATIVE_INFINITY && Randomizer.nextDouble() < Math.exp(logAlpha))) {
                 // accept
                 oldLogLikelihood = newLogLikelihood;
                 state.acceptCalculationNodes();


### PR DESCRIPTION
If the target distribution for the proposed state is -infinity, `MCMC` still makes the call to `Randomizer.nextDouble()` to test for acceptance.  This patch removes that call, as nextDouble() an expensive method.