### PR TITLE
Fixed Sequence.initProbabilities to check number of states for each site (#1077)

### DIFF
--- a/src/beast/base/evolution/alignment/Sequence.java
+++ b/src/beast/base/evolution/alignment/Sequence.java
@@ -84,6 +84,9 @@ public class Sequence extends BEASTObject {
 			//double total = 0;
     		for (int j=0; j<pr.length; j++) {    			
     			if (likelihoods == null) likelihoods = new double[strs.length][pr.length];
+                if (likelihoods != null && likelihoods[i].length != pr.length) {
+                    likelihoods[i] = new double[pr.length];
+                }
     			likelihoods[i][j] = Double.parseDouble(pr[j].trim());
     			//total += likelihoods[i][j]; 
     		}    		


### PR DESCRIPTION
In `Sequence.initProbabilities`, I added a line to ensure that when sequences are uncertain (i.e., use tip likelihoods), sites with different numbers of states do not cause the method to throw an `ArrayIndexOutOfBoundsException`. This should resolve #1077.