### PR TITLE
Fix encoding

### DIFF
--- a/src/beast/base/evolution/operator/EpochFlexOperator.java
+++ b/src/beast/base/evolution/operator/EpochFlexOperator.java
@@ -127,15 +127,15 @@ public class EpochFlexOperator extends Operator {
 //
 //			Subtract second form first:
 //
-//			h1’-h2’ = s * (h1-h2) so s =  (h1’-h2’)/(h1-h2). Fill s in first equation gives L.
+//			h1'-h2' = s * (h1-h2) so s =  (h1'-h2')/(h1-h2). Fill s in first equation gives L.
 //
 //			Given two more nodes above U at heights h3, h4
 //
-//			h3’ = h3 + delta
+//			h3' = h3 + delta
 //
-//			so delta = h3’ - h3
+//			so delta = h3' - h3
 //
-//			delta = U’ - U where U’ = L + s * (U-L) so
+//			delta = U' - U where U' = L + s * (U-L) so
 //			delta = L + s * (U-L) - U =>
 //			delta = (1+s)L + (s-1)U
 //			U = (delta - (1+s)L)/(s-1)

--- a/src/beast/base/inference/CalculationNode.java
+++ b/src/beast/base/inference/CalculationNode.java
@@ -148,14 +148,14 @@ public abstract class CalculationNode extends BEASTObject {
     protected int preOperatorChecksum;
 
     /**
-     * Store the current checksum as the ´preOperatorChecksum´.
+     * Store the current checksum as the 'preOperatorChecksum'.
      */
     public void storeChecksum() {
         preOperatorChecksum = getChecksum();
     }
 
     /**
-     * Check whether the current checksum matches the ´preOperatorChecksum´.
+     * Check whether the current checksum matches the 'preOperatorChecksum'.
      * @return true iff the checksums match
      */
     public boolean matchesOldChecksum() {

--- a/src/beast/base/inference/MCMC.java
+++ b/src/beast/base/inference/MCMC.java
@@ -52,9 +52,9 @@ import beast.base.util.Randomizer;
 //                "  evolutionary analysis. PLoS Computational Biology 10(4): e1003537"
 //        , year = 2014, firstAuthorSurname = "bouckaert",
 //        DOI="10.1371/journal.pcbi.1003537")
-@Citation(value="Bouckaert, Remco, Timothy G. Vaughan, Joëlle Barido-Sottani, Sebastián Duchêne, Mathieu Fourment, \n"
-		+ "Alexandra Gavryushkina, Joseph Heled, Graham Jones, Denise Kühnert, Nicola De Maio, Michael Matschiner, \n"
-        + "Fábio K. Mendes, Nicola F. Müller, Huw A. Ogilvie, Louis du Plessis, Alex Popinga, Andrew Rambaut, \n"
+@Citation(value="Bouckaert, Remco, Timothy G. Vaughan, Joelle Barido-Sottani, Sebastian Duchene, Mathieu Fourment, \n"
+		+ "Alexandra Gavryushkina, Joseph Heled, Graham Jones, Denise Kuehnert, Nicola De Maio, Michael Matschiner, \n"
+        + "Fabio K. Mendes, Nicola F. Mueller, Huw A. Ogilvie, Louis du Plessis, Alex Popinga, Andrew Rambaut, \n"
         + "David Rasmussen, Igor Siveroni, Marc A. Suchard, Chieh-Hsi Wu, Dong Xie, Chi Zhang, Tanja Stadler, \n"
         + "Alexei J. Drummond \n"
 		+ "  BEAST 2.5: An advanced software platform for Bayesian evolutionary analysis. \n"

--- a/src/beast/base/inference/operator/kernel/KernelDistribution.java
+++ b/src/beast/base/inference/operator/kernel/KernelDistribution.java
@@ -106,7 +106,7 @@ public interface KernelDistribution {
 				b = 0.5 * (Math.sqrt(12-3 * a * a) - a);
 				break;
 	        case bactrian_airplane: {
-	        	// b is root of 4b^3−12b+6a−a^3=0
+	        	// b is root of 4b^3-12b+6a-a^3=0
 	        	// which according to https://www.wolframalpha.com/input/?i=4x%5E3%E2%88%9212x%2B6a%E2%88%92a%5E3%3D0
 	        	// is below (the other two roots are imaginary)
 	        	double a2 = a * a;
@@ -117,7 +117,7 @@ public interface KernelDistribution {
 					2/Math.pow(a3 + Math.sqrt(a6 - 12 * a4 + 36 * a2 - 64) - 6 * a,1.0/3.0);
 	        } break;
 	        case bactrian_strawhat: {
-	        	// b is root of 5x^3−15x+10a−2a^3
+	        	// b is root of 5x^3-15x+10a-2a^3
 	        	// which according to https://www.wolframalpha.com/input/?i=5x%5E3%E2%88%9215x%2B10a%E2%88%922a%5E3
 	        	// is 
 	        	// x = (a^3 + sqrt(a^6 - 10 a^4 + 25 a^2 - 25) - 5 a)^(1/3)/5^(1/3) + 5^(1/3)/(a^3 + sqrt(a^6 - 10 a^4 + 25 a^2 - 25) - 5 a)^(1/3)


### PR DESCRIPTION
The PR aims to fix some encoding within the comment that triggers errors during the build.

```
    [javac] /opt/beast2/src/beast/base/inference/MCMC.java:55: error: unmappable character (0xC3) for encoding US-ASCII
    [javac] @Citation(value="Bouckaert, Remco, Timothy G. Vaughan, Jo??lle Barido-Sottani, Sebasti??n Duch??ne, Mathieu Fourment, \n"
    [javac]                                                          ^
    [javac] /opt/beast2/src/beast/base/inference/MCMC.java:55: error: unmappable character (0xAB) for encoding US-ASCII
    [javac] @Citation(value="Bouckaert, Remco, Timothy G. Vaughan, Jo??lle Barido-Sottani, Sebasti??n Duch??ne, Mathieu Fourment, \n"
    [javac]                                                           ^
    [javac] /opt/beast2/src/beast/base/inference/MCMC.java:55: error: unmappable character (0xC3) for encoding US-ASCII
    [javac] @Citation(value="Bouckaert, Remco, Timothy G. Vaughan, Jo??lle Barido-Sottani, Sebasti??n Duch??ne, Mathieu Fourment, \n"
    [javac]                                                                                                 ^
 [•••]
    [javac] 	        	                              ^
    [javac] /opt/beast2/src/beast/base/inference/operator/kernel/KernelDistribution.java:120: error: unmappable character (0x88) for encoding US-ASCII
    [javac] 	        	// b is root of 5x^3???15x+10a???2a^3
    [javac] 	        	                               ^
    [javac] /opt/beast2/src/beast/base/inference/operator/kernel/KernelDistribution.java:120: error: unmappable character (0x92) for encoding US-ASCII
    [javac] 	        	// b is root of 5x^3???15x+10a???2a^3
    [javac] 	        	                                ^
    [javac] 56 errors

BUILD FAILED
/opt/beast2/build.xml:142: Compile failed; see the compiler error output for details.
```