### PR TITLE
generalise Dirichlet Distribution to deal with vectors that do not sum to 1 #1190

### DIFF
--- a/src/beast/base/inference/distribution/Dirichlet.java
+++ b/src/beast/base/inference/distribution/Dirichlet.java
@@ -78,20 +78,8 @@ public class Dirichlet extends ParametricDistribution {
             sumX += pX.getArrayValue(i);
         }
 
-        // normalise X if sum != 1
-        if (sumX != 1){
-            for (int i = 0; i < pX.getDimension(); i++) {
-                normalisedX[i] = pX.getArrayValue(i) / sumX;
-            }
-        }
-
         for (int i = 0; i < pX.getDimension(); i++) {
-            double x = 0;
-            if (sumX == 1) {
-                x = pX.getArrayValue(i);
-            } else {
-                x = normalisedX[i];
-            }
+            double x = normalisedX[i] / sumX;
 
             logP += (alpha[i] - 1) * Math.log(x);
             logP -= org.apache.commons.math.special.Gamma.logGamma(alpha[i]);

--- a/src/beast/base/inference/distribution/Dirichlet.java
+++ b/src/beast/base/inference/distribution/Dirichlet.java
@@ -71,13 +71,35 @@ public class Dirichlet extends ParametricDistribution {
         }
         double logP = 0;
         double sumAlpha = 0;
+        double sumX = 0;
+        double[] normalisedX = new double[pX.getDimension()];
+        // check sumX first
         for (int i = 0; i < pX.getDimension(); i++) {
-            double x = pX.getArrayValue(i);
+            sumX += pX.getArrayValue(i);
+        }
+
+        // normalise X if sum != 1
+        if (sumX != 1){
+            for (int i = 0; i < pX.getDimension(); i++) {
+                normalisedX[i] = pX.getArrayValue(i) / sumX;
+            }
+        }
+
+        for (int i = 0; i < pX.getDimension(); i++) {
+            double x = 0;
+            if (sumX == 1) {
+                x = pX.getArrayValue(i);
+            } else {
+                x = normalisedX[i];
+            }
+
             logP += (alpha[i] - 1) * Math.log(x);
             logP -= org.apache.commons.math.special.Gamma.logGamma(alpha[i]);
             sumAlpha += alpha[i];
         }
+
         logP += org.apache.commons.math.special.Gamma.logGamma(sumAlpha);
+        logP -= (pX.getDimension() - 1) * Math.log(sumX);
         return logP;
     }
 

--- a/test/test/beast/evolution/inference/DirichletTest.java
+++ b/test/test/beast/evolution/inference/DirichletTest.java
@@ -1,0 +1,98 @@
+package test.beast.evolution.inference;
+
+import beast.base.inference.distribution.Dirichlet;
+import beast.base.inference.parameter.RealParameter;
+import org.apache.commons.math.special.Gamma;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DirichletTest {
+    @Test
+    void normalisedTest() {
+        Dirichlet d = new Dirichlet();
+
+        Double[] alpha = new Double[]{1.0, 1.0, 1.0, 1.0, 1.0};
+        RealParameter a = new RealParameter(alpha);
+        d.alphaInput.setValue(a, d );
+        d.initAndValidate();
+
+        int n = alpha.length;
+
+        // Valid Dirichlet vector: sum to 1
+        Double[] x = new Double[]{0.2, 0.2, 0.2, 0.2, 0.2};
+        RealParameter p = new RealParameter(x);
+        double f0 = d.calcLogP(p);
+
+        // Compute expected log density
+        double sumAlpha = 0.0;
+        for (int i = 0; i < n; i++) {
+            sumAlpha += alpha[i];
+        }
+
+        double logGammaSumAlpha = Gamma.logGamma(sumAlpha);
+
+        double sumLogGammaAlpha = 0.0;
+        for (int i = 0; i < n; i++) {
+            sumLogGammaAlpha += Gamma.logGamma(alpha[i]);
+        }
+
+        double sumLogX = 0.0;
+        for (int i = 0; i < n; i++) {
+            sumLogX += (alpha[i] - 1.0) * Math.log(x[i]);
+        }
+
+        double exp = logGammaSumAlpha - sumLogGammaAlpha + sumLogX;
+
+        assertEquals(exp, f0, 1e-6);
+    }
+
+    @Test
+    void notNormalisedTest() {
+        Dirichlet d = new Dirichlet();
+
+        Double[] alpha = new Double[]{1.0, 1.0, 1.0, 1.0, 1.0};
+        RealParameter a = new RealParameter(alpha);
+        d.alphaInput.setValue(a, d );
+        d.initAndValidate();
+
+        int n = alpha.length;
+
+        // Define x whose sum is sumX (not 1)
+        Double[] x = new Double[]{1.0, 1.0, 1.0, 1.0, 1.0}; // sum = 5 (sumX=5)
+        RealParameter p = new RealParameter(x);
+        double f0 = d.calcLogP(p);
+
+        // Compute sumX = sum(x)
+        double sumX = 0.0;
+        for (int i = 0; i < n; i++) {
+            sumX += x[i];
+        }
+
+        // Compute standard log density for x_normalised
+        double sumAlpha = 0.0;
+        for (int i = 0; i < n; i++) {
+            sumAlpha += alpha[i];
+        }
+
+        double logGammaSumAlpha = Gamma.logGamma(sumAlpha);
+
+        double sumLogGammaAlpha = 0.0;
+        for (int i = 0; i < n; i++) {
+            sumLogGammaAlpha += Gamma.logGamma(alpha[i]);
+        }
+
+        // Normalised x (so xi / sumX)
+        double sumLogX = 0.0;
+        for (int i = 0; i < n; i++) {
+            sumLogX += (alpha[i] - 1.0) * Math.log(x[i] / sumX);
+        }
+
+        double log_density_standard = logGammaSumAlpha - sumLogGammaAlpha + sumLogX;
+
+        // Apply Jacobian correction: -(n-1) * log(sumX)
+        double log_density_scaled = log_density_standard - (n - 1) * Math.log(sumX);
+
+        assertEquals(log_density_scaled, f0, 1e-6);
+    }
+}


### PR DESCRIPTION
Solution: normalise the input vector so that its components sum to 1.
Compensate for the space reduction by adding a constant `log(sum)* (dimension-1)`.